### PR TITLE
feat(v1): implement tool-call loop in agent run

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,3 +22,7 @@ tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use harness_core::{
     config::Config,
-    message::Message,
+    message::{ContentBlock, Message, MessageContent, Role, StopReason},
     provider::Provider,
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
 use harness_tools::{ToolRegistry, builtin::EchoTool};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
@@ -49,6 +49,9 @@ impl Agent {
             self.config.agent.max_iterations
         };
 
+        // Convert registered tool schemas to ToolDefs for the provider.
+        let tool_defs: Vec<_> = self.tools.schemas().iter().map(|s| s.to_def()).collect();
+
         loop {
             if session.iteration >= max_iter {
                 info!("max iterations reached");
@@ -56,28 +59,243 @@ impl Agent {
                 break;
             }
 
+            session.iteration += 1;
             debug!(iteration = session.iteration, "agent turn");
-            let response = self.provider.complete(&messages).await?;
 
-            let text = response.message.text().unwrap_or("").to_string();
-            info!(tokens_out = response.usage.output_tokens, "← {}", &text[..text.len().min(120)]);
+            let response = self.provider.complete_with_tools(&messages, &tool_defs).await?;
 
-            // Record in session
+            let preview = response.message.text().unwrap_or("").to_string();
+            info!(
+                tokens_out = response.usage.output_tokens,
+                stop_reason = ?response.stop_reason,
+                "← {}",
+                &preview[..preview.len().min(120)]
+            );
+
+            // Append assistant message to running history and session log.
+            messages.push(response.message.clone());
             session.push(response.message.clone());
 
-            // Persist to memory
-            let ep = harness_memory::Episode::turn(
-                session.id,
-                "assistant",
-                response.message.text().unwrap_or(""),
-            );
-            self.memory.insert(&ep).await?;
+            match response.stop_reason {
+                StopReason::EndTurn | StopReason::StopSequence | StopReason::MaxTokens => {
+                    // Persist final assistant turn to memory.
+                    let ep = harness_memory::Episode::turn(
+                        session.id,
+                        "assistant",
+                        response.message.text().unwrap_or(""),
+                    );
+                    self.memory.insert(&ep).await?;
+                    session.finish(SessionStatus::Done);
+                    break;
+                }
 
-            // For v0: stop after one assistant turn (no tool loop yet)
-            session.finish(SessionStatus::Done);
-            break;
+                StopReason::ToolUse => {
+                    // Extract every ToolUse block from the assistant response.
+                    let tool_calls: Vec<(String, String, serde_json::Value)> =
+                        match &response.message.content {
+                            MessageContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| {
+                                    if let ContentBlock::ToolUse { id, name, input } = b {
+                                        Some((id.clone(), name.clone(), input.clone()))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                            _ => {
+                                warn!("stop_reason=ToolUse but no ToolUse blocks found; treating as EndTurn");
+                                session.finish(SessionStatus::Done);
+                                break;
+                            }
+                        };
+
+                    // Execute each tool and collect result blocks.
+                    let mut result_blocks: Vec<ContentBlock> = Vec::new();
+                    for (tool_use_id, name, input) in tool_calls {
+                        info!(tool = %name, "→ calling tool");
+                        let output = self.tools.call(&name, input).await;
+                        if output.is_error {
+                            warn!(tool = %name, "tool returned error: {}", output.content);
+                        }
+                        result_blocks.push(ContentBlock::ToolResult {
+                            tool_use_id,
+                            content: output.content,
+                        });
+                    }
+
+                    // Feed results back as a user-role message and continue.
+                    let tool_result_msg = Message {
+                        role: Role::User,
+                        content: MessageContent::Blocks(result_blocks),
+                    };
+                    messages.push(tool_result_msg.clone());
+                    session.push(tool_result_msg);
+                }
+            }
         }
 
         Ok(session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use harness_core::{
+        message::{ContentBlock, MessageContent, Role, StopReason, TurnResponse, Usage},
+        provider::Provider,
+    };
+    use harness_tools::builtin::EchoTool;
+    use std::sync::{Arc, Mutex};
+
+    /// Provider that pops responses from a pre-loaded queue.
+    struct ScriptedProvider {
+        responses: Mutex<Vec<TurnResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<TurnResponse>) -> Self {
+            // Reverse so we can pop from the back in FIFO order.
+            let mut r = responses;
+            r.reverse();
+            Self { responses: Mutex::new(r) }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[harness_core::message::Message],
+        ) -> harness_core::error::Result<TurnResponse> {
+            let mut guard = self.responses.lock().unwrap();
+            Ok(guard.pop().expect("ScriptedProvider ran out of responses"))
+        }
+    }
+
+    fn make_config(max_iterations: usize) -> harness_core::config::Config {
+        let mut cfg = harness_core::config::Config::default();
+        cfg.agent.max_iterations = max_iterations;
+        cfg.agent.system_prompt = None;
+        cfg
+    }
+
+    async fn make_memory() -> Arc<MemoryDb> {
+        Arc::new(MemoryDb::in_memory().await.unwrap())
+    }
+
+    /// Helpers for building TurnResponse values.
+    fn tool_use_response(tool_use_id: &str, tool_name: &str, input: serde_json::Value) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: tool_use_id.to_string(),
+                        name: tool_name.to_string(),
+                        input,
+                    },
+                ]),
+            },
+            stop_reason: StopReason::ToolUse,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    fn end_turn_response(text: &str) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+            },
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_loop_calls_tool_and_continues() {
+        // Turn 1: provider requests an echo tool call.
+        // Turn 2: provider returns EndTurn after seeing the tool result.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("call-1", "echo", serde_json::json!({"message": "ping"})),
+            end_turn_response("done"),
+        ]));
+
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let agent = Agent {
+            provider: provider.clone(),
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // messages: system + user + assistant(tool_use) + user(tool_result) + assistant(end_turn)
+        assert_eq!(session.messages.len(), 3); // assistant(tool_use) + user(tool_result) + assistant(end_turn)
+    }
+
+    #[tokio::test]
+    async fn max_iterations_cap_is_respected() {
+        // Provider always asks for a tool call; cap at 2 iterations.
+        let responses: Vec<TurnResponse> = (0..10)
+            .map(|i| tool_use_response(&format!("c-{i}"), "echo", serde_json::json!({"message": "x"})))
+            .collect();
+
+        let provider = Arc::new(ScriptedProvider::new(responses));
+        let memory = make_memory().await;
+        let config = make_config(2);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("loop forever").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 2);
+    }
+
+    #[tokio::test]
+    async fn end_turn_stops_without_tool_calls() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response("hello")]));
+        let memory = make_memory().await;
+        let config = make_config(5);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: ToolRegistry::new(),
+            config,
+        };
+
+        let session = agent.run("simple goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 1);
+        assert_eq!(session.messages.len(), 1); // only the assistant response
     }
 }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,7 +1,17 @@
 use async_trait::async_trait;
 use std::pin::Pin;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use crate::{error::Result, message::{Message, TurnResponse}};
+
+/// Lightweight tool definition passed to providers alongside messages.
+/// Mirrors the JSON schema shape expected by Claude / OpenAI tool-calling APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
 
 /// A streaming token chunk from the provider.
 #[derive(Debug, Clone)]
@@ -22,6 +32,16 @@ pub trait Provider: Send + Sync + 'static {
 
     /// Single non-streaming turn: send messages, get back a complete response.
     async fn complete(&self, messages: &[Message]) -> Result<TurnResponse>;
+
+    /// Turn with tool definitions made available to the LLM.
+    /// Defaults to `complete` (tools ignored) for providers that don't support them yet.
+    async fn complete_with_tools(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
+        self.complete(messages).await
+    }
 
     /// Streaming turn: yields token chunks as they arrive.
     /// Default falls back to `complete` and emits one chunk.

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -20,3 +20,24 @@ impl ToolHandler for EchoTool {
         ToolOutput::ok(msg)
     }
 }
+
+/// Read the UTF-8 contents of a file at a given path.
+pub struct ReadFileTool;
+
+#[async_trait]
+impl ToolHandler for ReadFileTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::simple("read_file", "Read the UTF-8 contents of a file", &["path"])
+    }
+
+    async fn call(&self, input: Value) -> ToolOutput {
+        let path = match input["path"].as_str() {
+            Some(p) => p.to_string(),
+            None => return ToolOutput::err("missing required field: path"),
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => ToolOutput::ok(contents),
+            Err(e) => ToolOutput::err(format!("read_file failed for {path}: {e}")),
+        }
+    }
+}

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -1,3 +1,4 @@
+use harness_core::provider::ToolDef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -26,6 +27,15 @@ impl ToolSchema {
                 "properties": properties,
                 "required": required_strings,
             }),
+        }
+    }
+
+    /// Convert to a `ToolDef` for passing to provider methods.
+    pub fn to_def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: self.input_schema.clone(),
         }
     }
 


### PR DESCRIPTION
- Add `ToolDef` to harness-core and `complete_with_tools` default method to the Provider trait (backward-compatible, defaults to `complete`)
- Replace single-turn break in agent.rs with a full loop: continues on StopReason::ToolUse, dispatches to ToolRegistry, feeds ToolResult messages back, stops on EndTurn/StopSequence/MaxTokens or max_iterations
- Add `ReadFileTool` builtin beyond the echo stub
- Add `ToolSchema::to_def()` conversion helper in harness-tools
- Integration tests: ScriptedProvider verifies loop dispatch, tool calls, max_iterations cap, and simple end-turn path (8 tests, all green)

Closes ANGA-261