### PR TITLE
feat(v2): real SSE streaming + harness eval subcommand

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,3 +22,7 @@ tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use harness_core::{
     config::Config,
-    message::Message,
+    message::{ContentBlock, Message, MessageContent, Role, StopReason},
     provider::Provider,
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
 use harness_tools::{ToolRegistry, builtin::EchoTool};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
@@ -49,6 +49,9 @@ impl Agent {
             self.config.agent.max_iterations
         };
 
+        // Convert registered tool schemas to ToolDefs for the provider.
+        let tool_defs: Vec<_> = self.tools.schemas().iter().map(|s| s.to_def()).collect();
+
         loop {
             if session.iteration >= max_iter {
                 info!("max iterations reached");
@@ -56,28 +59,243 @@ impl Agent {
                 break;
             }
 
+            session.iteration += 1;
             debug!(iteration = session.iteration, "agent turn");
-            let response = self.provider.complete(&messages).await?;
 
-            let text = response.message.text().unwrap_or("").to_string();
-            info!(tokens_out = response.usage.output_tokens, "← {}", &text[..text.len().min(120)]);
+            let response = self.provider.complete_with_tools(&messages, &tool_defs).await?;
 
-            // Record in session
+            let preview = response.message.text().unwrap_or("").to_string();
+            info!(
+                tokens_out = response.usage.output_tokens,
+                stop_reason = ?response.stop_reason,
+                "← {}",
+                &preview[..preview.len().min(120)]
+            );
+
+            // Append assistant message to running history and session log.
+            messages.push(response.message.clone());
             session.push(response.message.clone());
 
-            // Persist to memory
-            let ep = harness_memory::Episode::turn(
-                session.id,
-                "assistant",
-                response.message.text().unwrap_or(""),
-            );
-            self.memory.insert(&ep).await?;
+            match response.stop_reason {
+                StopReason::EndTurn | StopReason::StopSequence | StopReason::MaxTokens => {
+                    // Persist final assistant turn to memory.
+                    let ep = harness_memory::Episode::turn(
+                        session.id,
+                        "assistant",
+                        response.message.text().unwrap_or(""),
+                    );
+                    self.memory.insert(&ep).await?;
+                    session.finish(SessionStatus::Done);
+                    break;
+                }
 
-            // For v0: stop after one assistant turn (no tool loop yet)
-            session.finish(SessionStatus::Done);
-            break;
+                StopReason::ToolUse => {
+                    // Extract every ToolUse block from the assistant response.
+                    let tool_calls: Vec<(String, String, serde_json::Value)> =
+                        match &response.message.content {
+                            MessageContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| {
+                                    if let ContentBlock::ToolUse { id, name, input } = b {
+                                        Some((id.clone(), name.clone(), input.clone()))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                            _ => {
+                                warn!("stop_reason=ToolUse but no ToolUse blocks found; treating as EndTurn");
+                                session.finish(SessionStatus::Done);
+                                break;
+                            }
+                        };
+
+                    // Execute each tool and collect result blocks.
+                    let mut result_blocks: Vec<ContentBlock> = Vec::new();
+                    for (tool_use_id, name, input) in tool_calls {
+                        info!(tool = %name, "→ calling tool");
+                        let output = self.tools.call(&name, input).await;
+                        if output.is_error {
+                            warn!(tool = %name, "tool returned error: {}", output.content);
+                        }
+                        result_blocks.push(ContentBlock::ToolResult {
+                            tool_use_id,
+                            content: output.content,
+                        });
+                    }
+
+                    // Feed results back as a user-role message and continue.
+                    let tool_result_msg = Message {
+                        role: Role::User,
+                        content: MessageContent::Blocks(result_blocks),
+                    };
+                    messages.push(tool_result_msg.clone());
+                    session.push(tool_result_msg);
+                }
+            }
         }
 
         Ok(session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use harness_core::{
+        message::{ContentBlock, MessageContent, Role, StopReason, TurnResponse, Usage},
+        provider::Provider,
+    };
+    use harness_tools::builtin::EchoTool;
+    use std::sync::{Arc, Mutex};
+
+    /// Provider that pops responses from a pre-loaded queue.
+    struct ScriptedProvider {
+        responses: Mutex<Vec<TurnResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<TurnResponse>) -> Self {
+            // Reverse so we can pop from the back in FIFO order.
+            let mut r = responses;
+            r.reverse();
+            Self { responses: Mutex::new(r) }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[harness_core::message::Message],
+        ) -> harness_core::error::Result<TurnResponse> {
+            let mut guard = self.responses.lock().unwrap();
+            Ok(guard.pop().expect("ScriptedProvider ran out of responses"))
+        }
+    }
+
+    fn make_config(max_iterations: usize) -> harness_core::config::Config {
+        let mut cfg = harness_core::config::Config::default();
+        cfg.agent.max_iterations = max_iterations;
+        cfg.agent.system_prompt = None;
+        cfg
+    }
+
+    async fn make_memory() -> Arc<MemoryDb> {
+        Arc::new(MemoryDb::in_memory().await.unwrap())
+    }
+
+    /// Helpers for building TurnResponse values.
+    fn tool_use_response(tool_use_id: &str, tool_name: &str, input: serde_json::Value) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: tool_use_id.to_string(),
+                        name: tool_name.to_string(),
+                        input,
+                    },
+                ]),
+            },
+            stop_reason: StopReason::ToolUse,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    fn end_turn_response(text: &str) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+            },
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_loop_calls_tool_and_continues() {
+        // Turn 1: provider requests an echo tool call.
+        // Turn 2: provider returns EndTurn after seeing the tool result.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("call-1", "echo", serde_json::json!({"message": "ping"})),
+            end_turn_response("done"),
+        ]));
+
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let agent = Agent {
+            provider: provider.clone(),
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // messages: system + user + assistant(tool_use) + user(tool_result) + assistant(end_turn)
+        assert_eq!(session.messages.len(), 3); // assistant(tool_use) + user(tool_result) + assistant(end_turn)
+    }
+
+    #[tokio::test]
+    async fn max_iterations_cap_is_respected() {
+        // Provider always asks for a tool call; cap at 2 iterations.
+        let responses: Vec<TurnResponse> = (0..10)
+            .map(|i| tool_use_response(&format!("c-{i}"), "echo", serde_json::json!({"message": "x"})))
+            .collect();
+
+        let provider = Arc::new(ScriptedProvider::new(responses));
+        let memory = make_memory().await;
+        let config = make_config(2);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("loop forever").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 2);
+    }
+
+    #[tokio::test]
+    async fn end_turn_stops_without_tool_calls() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response("hello")]));
+        let memory = make_memory().await;
+        let config = make_config(5);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: ToolRegistry::new(),
+            config,
+        };
+
+        let session = agent.run("simple goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 1);
+        assert_eq!(session.messages.len(), 1); // only the assistant response
     }
 }

--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+
+use clap::Args;
+use harness_core::{config::Config, provider::Provider, providers::ClaudeProvider};
+use harness_memory::MemoryDb;
+use serde::Deserialize;
+
+use crate::agent::Agent;
+
+/// A single evaluation test case (one line in the JSONL file).
+#[derive(Debug, Deserialize)]
+struct EvalCase {
+    /// The goal / prompt to send to the agent.
+    goal: String,
+    /// Expected substring that must appear in the agent's final response.
+    expected: String,
+    /// Optional human-readable label for this case.
+    #[serde(default)]
+    label: Option<String>,
+}
+
+#[derive(Args)]
+pub struct EvalArgs {
+    /// Path to a JSONL file where each line is {"goal":"...","expected":"..."}
+    #[arg(short, long)]
+    pub cases: String,
+
+    /// Provider backend (claude, echo). Defaults to config value.
+    #[arg(long, env = "HARNESS_PROVIDER")]
+    pub provider: Option<String>,
+
+    /// Fail fast: stop after the first failing case
+    #[arg(long)]
+    pub fail_fast: bool,
+}
+
+pub async fn execute(args: EvalArgs) -> anyhow::Result<()> {
+    let config = Config::load()?;
+
+    // Load and parse the JSONL cases file.
+    let content = std::fs::read_to_string(&args.cases)
+        .map_err(|e| anyhow::anyhow!("failed to read cases file '{}': {}", args.cases, e))?;
+
+    let cases: Vec<EvalCase> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .enumerate()
+        .map(|(i, line)| {
+            serde_json::from_str::<EvalCase>(line)
+                .map_err(|e| anyhow::anyhow!("line {}: invalid JSON: {}", i + 1, e))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    if cases.is_empty() {
+        anyhow::bail!("no test cases found in '{}'", args.cases);
+    }
+
+    let backend = args.provider.as_deref().unwrap_or(&config.provider.backend).to_string();
+    let provider: Arc<dyn Provider> = match backend.as_str() {
+        "echo" => {
+            tracing::info!("using echo provider (no LLM calls)");
+            Arc::new(harness_core::provider::EchoProvider)
+        }
+        _ => {
+            let api_key = config.resolved_api_key().ok_or_else(|| {
+                anyhow::anyhow!("ANTHROPIC_API_KEY not set — pass via env or config")
+            })?;
+            Arc::new(ClaudeProvider::new(
+                api_key,
+                &config.provider.model,
+                config.provider.max_tokens,
+            ))
+        }
+    };
+
+    let memory = Arc::new(MemoryDb::in_memory().await?);
+
+    println!("Running {} eval case(s) with provider '{}'", cases.len(), backend);
+    println!("{}", "─".repeat(60));
+
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut failures: Vec<(usize, String, String, String)> = Vec::new(); // (idx, label, got, expected)
+
+    for (idx, case) in cases.iter().enumerate() {
+        let label = case
+            .label
+            .as_deref()
+            .map(|l| l.to_string())
+            .unwrap_or_else(|| format!("case {}", idx + 1));
+
+        let agent = Agent::new(Arc::clone(&provider), Arc::clone(&memory), config.clone());
+        let session = agent.run(&case.goal).await?;
+
+        let response = session
+            .messages
+            .last()
+            .and_then(|m| m.text())
+            .unwrap_or("")
+            .to_string();
+
+        let pass =
+            response.to_lowercase().contains(&case.expected.to_lowercase());
+
+        if pass {
+            passed += 1;
+            println!("[PASS] {}", label);
+        } else {
+            failed += 1;
+            println!("[FAIL] {}", label);
+            println!("       expected to contain: {:?}", case.expected);
+            println!("       got:                 {:?}", &response[..response.len().min(120)]);
+            failures.push((idx + 1, label.clone(), response, case.expected.clone()));
+
+            if args.fail_fast {
+                println!("\nStopping early (--fail-fast).");
+                break;
+            }
+        }
+    }
+
+    println!("{}", "─".repeat(60));
+    println!("Results: {}/{} passed", passed, passed + failed);
+
+    if failed > 0 {
+        anyhow::bail!("{} case(s) failed", failed);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EvalCase;
+
+    #[test]
+    fn parses_eval_case_json() {
+        let line = r#"{"goal":"What is 2+2?","expected":"4"}"#;
+        let case: EvalCase = serde_json::from_str(line).unwrap();
+        assert_eq!(case.goal, "What is 2+2?");
+        assert_eq!(case.expected, "4");
+        assert!(case.label.is_none());
+    }
+
+    #[test]
+    fn parses_eval_case_with_label() {
+        let line = r#"{"goal":"hello","expected":"world","label":"greeting"}"#;
+        let case: EvalCase = serde_json::from_str(line).unwrap();
+        assert_eq!(case.label.as_deref(), Some("greeting"));
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod memory;
+pub mod eval;
 pub mod run;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,7 +1,9 @@
+use std::io::Write as IoWrite;
 use std::sync::Arc;
 
 use clap::Args;
-use harness_core::{config::Config, providers::ClaudeProvider, provider::Provider};
+use futures::StreamExt;
+use harness_core::{config::Config, provider::Provider, providers::ClaudeProvider};
 use harness_memory::MemoryDb;
 
 use crate::agent::Agent;
@@ -15,6 +17,10 @@ pub struct RunArgs {
     /// Provider backend override (claude, echo)
     #[arg(long, env = "HARNESS_PROVIDER")]
     pub provider: Option<String>,
+
+    /// Stream response tokens to stdout as they arrive
+    #[arg(long)]
+    pub stream: bool,
 }
 
 pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
@@ -26,25 +32,71 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
             tracing::info!("using echo provider (no LLM calls)");
             Arc::new(harness_core::provider::EchoProvider)
         }
-        "claude" | _ => {
+        _ => {
             let api_key = config.resolved_api_key().ok_or_else(|| {
                 anyhow::anyhow!("ANTHROPIC_API_KEY not set — pass via env or config")
             })?;
-            Arc::new(ClaudeProvider::new(api_key, &config.provider.model, config.provider.max_tokens))
+            Arc::new(ClaudeProvider::new(
+                api_key,
+                &config.provider.model,
+                config.provider.max_tokens,
+            ))
         }
     };
 
     let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
 
-    let agent = Agent::new(provider, memory, config);
-    let session = agent.run(&args.goal).await?;
+    if args.stream {
+        // Streaming mode: print tokens as they arrive, then persist to memory.
+        let msgs = vec![
+            harness_core::message::Message::system(
+                config
+                    .agent
+                    .system_prompt
+                    .as_deref()
+                    .unwrap_or("You are a helpful assistant. Complete the user's goal concisely."),
+            ),
+            harness_core::message::Message::user(&args.goal),
+        ];
 
-    println!("\n{}", "─".repeat(60));
-    if let Some(msg) = session.messages.last() {
-        println!("{}", msg.text().unwrap_or("(no response)"));
+        println!("\n{}", "─".repeat(60));
+        let mut token_stream = provider.stream(&msgs).await?;
+        let mut full_text = String::new();
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+
+        while let Some(chunk) = token_stream.next().await {
+            let chunk = chunk?;
+            if !chunk.delta.is_empty() {
+                full_text.push_str(&chunk.delta);
+                write!(out, "{}", chunk.delta)?;
+                out.flush()?;
+            }
+            if chunk.done {
+                break;
+            }
+        }
+
+        writeln!(out)?;
+        println!("{}", "─".repeat(60));
+
+        // Persist the streamed response to memory.
+        let ep =
+            harness_memory::Episode::turn(uuid::Uuid::new_v4(), "assistant", &full_text);
+        memory.insert(&ep).await?;
+
+        println!("Streaming complete.");
+    } else {
+        let agent = Agent::new(provider, memory, config);
+        let session = agent.run(&args.goal).await?;
+
+        println!("\n{}", "─".repeat(60));
+        if let Some(msg) = session.messages.last() {
+            println!("{}", msg.text().unwrap_or("(no response)"));
+        }
+        println!("{}", "─".repeat(60));
+        println!("Session: {} | Status: {:?}", session.id, session.status);
     }
-    println!("{}", "─".repeat(60));
-    println!("Session: {} | Status: {:?}", session.id, session.status);
 
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,8 @@ enum Commands {
     Config(commands::config::ConfigArgs),
     /// Manage and inspect memory
     Memory(commands::memory::MemoryArgs),
+    /// Batch-evaluate agent against a JSONL test suite
+    Eval(commands::eval::EvalArgs),
 }
 
 #[tokio::main]
@@ -41,5 +43,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Run(args) => commands::run::execute(args).await,
         Commands::Config(args) => commands::config::execute(args).await,
         Commands::Memory(args) => commands::memory::execute(args).await,
+        Commands::Eval(args) => commands::eval::execute(args).await,
     }
 }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,7 +1,17 @@
 use async_trait::async_trait;
 use std::pin::Pin;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use crate::{error::Result, message::{Message, TurnResponse}};
+
+/// Lightweight tool definition passed to providers alongside messages.
+/// Mirrors the JSON schema shape expected by Claude / OpenAI tool-calling APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
 
 /// A streaming token chunk from the provider.
 #[derive(Debug, Clone)]
@@ -22,6 +32,16 @@ pub trait Provider: Send + Sync + 'static {
 
     /// Single non-streaming turn: send messages, get back a complete response.
     async fn complete(&self, messages: &[Message]) -> Result<TurnResponse>;
+
+    /// Turn with tool definitions made available to the LLM.
+    /// Defaults to `complete` (tools ignored) for providers that don't support them yet.
+    async fn complete_with_tools(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
+        self.complete(messages).await
+    }
 
     /// Streaming turn: yields token chunks as they arrive.
     /// Default falls back to `complete` and emits one chunk.

--- a/crates/core/src/providers/claude.rs
+++ b/crates/core/src/providers/claude.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
+use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use crate::{
     error::{HarnessError, Result},
-    message::{Message, MessageContent, Role, StopReason, TurnResponse, Usage},
-    provider::Provider,
+    message::{ContentBlock, Message, MessageContent, Role, StopReason, TurnResponse, Usage},
+    provider::{Provider, StreamChunk, TokenStream, ToolDef},
 };
 
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -35,68 +36,11 @@ impl ClaudeProvider {
             .map_err(|_| HarnessError::Config("ANTHROPIC_API_KEY not set".to_string()))?;
         Ok(Self::new(key, model, max_tokens))
     }
-}
 
-// ── Anthropic API wire types ──────────────────────────────────────────────────
-
-#[derive(Serialize)]
-struct ApiRequest<'a> {
-    model: &'a str,
-    max_tokens: u32,
-    messages: Vec<ApiMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
-}
-
-#[derive(Serialize)]
-struct ApiMessage {
-    role: String,
-    content: serde_json::Value,
-}
-
-#[derive(Deserialize)]
-struct ApiResponse {
-    content: Vec<ApiContent>,
-    stop_reason: Option<String>,
-    usage: ApiUsage,
-    model: String,
-}
-
-#[derive(Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum ApiContent {
-    Text { text: String },
-    #[serde(other)]
-    Unknown,
-}
-
-#[derive(Deserialize)]
-struct ApiUsage {
-    input_tokens: u32,
-    output_tokens: u32,
-    cache_read_input_tokens: Option<u32>,
-    cache_creation_input_tokens: Option<u32>,
-}
-
-#[derive(Deserialize)]
-struct ApiError {
-    error: ApiErrorBody,
-}
-
-#[derive(Deserialize)]
-struct ApiErrorBody {
-    message: String,
-}
-
-// ── Provider impl ─────────────────────────────────────────────────────────────
-
-#[async_trait]
-impl Provider for ClaudeProvider {
-    fn name(&self) -> &str {
-        &self.model
-    }
-
-    async fn complete(&self, messages: &[Message]) -> Result<TurnResponse> {
+    fn build_api_messages(
+        &self,
+        messages: &[Message],
+    ) -> Result<(Option<String>, Vec<ApiMessage>)> {
         let mut system_prompt: Option<String> = None;
         let mut api_messages: Vec<ApiMessage> = Vec::new();
 
@@ -120,6 +64,149 @@ impl Provider for ClaudeProvider {
                 }
             }
         }
+
+        Ok((system_prompt, api_messages))
+    }
+}
+
+// ── Anthropic API wire types ──────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<ApiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ApiRequestWithTools<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<ApiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    tools: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct ApiStreamRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<ApiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    stream: bool,
+}
+
+#[derive(Serialize, Clone)]
+struct ApiMessage {
+    role: String,
+    content: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    content: Vec<ApiContent>,
+    stop_reason: Option<String>,
+    usage: ApiUsage,
+    model: String,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ApiContent {
+    Text { text: String },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct ApiUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_input_tokens: Option<u32>,
+    cache_creation_input_tokens: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    error: ApiErrorBody,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorBody {
+    message: String,
+}
+
+fn parse_stop_reason(s: Option<&str>) -> StopReason {
+    match s {
+        Some("max_tokens") => StopReason::MaxTokens,
+        Some("tool_use") => StopReason::ToolUse,
+        Some("stop_sequence") => StopReason::StopSequence,
+        _ => StopReason::EndTurn,
+    }
+}
+
+fn api_resp_to_turn(api_resp: ApiResponse) -> TurnResponse {
+    let stop_reason = parse_stop_reason(api_resp.stop_reason.as_deref());
+
+    let mut blocks: Vec<ContentBlock> = Vec::new();
+    for item in &api_resp.content {
+        match item {
+            ApiContent::Text { text } => {
+                if !text.is_empty() {
+                    blocks.push(ContentBlock::Text { text: text.clone() });
+                }
+            }
+            ApiContent::ToolUse { id, name, input } => {
+                blocks.push(ContentBlock::ToolUse {
+                    id: id.clone(),
+                    name: name.clone(),
+                    input: input.clone(),
+                });
+            }
+            ApiContent::Unknown => {}
+        }
+    }
+
+    let message = match blocks.len() {
+        0 => Message::assistant(""),
+        1 => {
+            if let ContentBlock::Text { text } = &blocks[0] {
+                Message::assistant(text.clone())
+            } else {
+                Message { role: Role::Assistant, content: MessageContent::Blocks(blocks) }
+            }
+        }
+        _ => Message { role: Role::Assistant, content: MessageContent::Blocks(blocks) },
+    };
+
+    TurnResponse {
+        message,
+        stop_reason,
+        usage: Usage {
+            input_tokens: api_resp.usage.input_tokens,
+            output_tokens: api_resp.usage.output_tokens,
+            cache_read_tokens: api_resp.usage.cache_read_input_tokens,
+            cache_write_tokens: api_resp.usage.cache_creation_input_tokens,
+        },
+        model: api_resp.model,
+    }
+}
+
+// ── Provider impl ─────────────────────────────────────────────────────────────
+
+#[async_trait]
+impl Provider for ClaudeProvider {
+    fn name(&self) -> &str {
+        &self.model
+    }
+
+    async fn complete(&self, messages: &[Message]) -> Result<TurnResponse> {
+        let (system_prompt, api_messages) = self.build_api_messages(messages)?;
 
         let body = ApiRequest {
             model: &self.model,
@@ -156,30 +243,169 @@ impl Provider for ClaudeProvider {
             .await
             .map_err(|e| HarnessError::Provider(e.to_string()))?;
 
-        let text = api_resp
-            .content
-            .iter()
-            .filter_map(|c| if let ApiContent::Text { text } = c { Some(text.as_str()) } else { None })
-            .collect::<Vec<_>>()
-            .join("");
+        Ok(api_resp_to_turn(api_resp))
+    }
 
-        let stop_reason = match api_resp.stop_reason.as_deref() {
-            Some("max_tokens") => StopReason::MaxTokens,
-            Some("tool_use") => StopReason::ToolUse,
-            Some("stop_sequence") => StopReason::StopSequence,
-            _ => StopReason::EndTurn,
+    async fn complete_with_tools(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
+        let (system_prompt, api_messages) = self.build_api_messages(messages)?;
+
+        let tool_defs: Vec<serde_json::Value> = tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.input_schema,
+                })
+            })
+            .collect();
+
+        let body = ApiRequestWithTools {
+            model: &self.model,
+            max_tokens: self.max_tokens,
+            messages: api_messages,
+            system: system_prompt,
+            tools: tool_defs,
         };
 
-        Ok(TurnResponse {
-            message: Message::assistant(text),
-            stop_reason,
-            usage: Usage {
-                input_tokens: api_resp.usage.input_tokens,
-                output_tokens: api_resp.usage.output_tokens,
-                cache_read_tokens: api_resp.usage.cache_read_input_tokens,
-                cache_write_tokens: api_resp.usage.cache_creation_input_tokens,
-            },
-            model: api_resp.model,
-        })
+        debug!(model = %self.model, tools = tools.len(), "sending tool-use request to Anthropic API");
+
+        let resp = self
+            .client
+            .post(ANTHROPIC_API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let raw = resp.text().await.unwrap_or_default();
+            let msg = serde_json::from_str::<ApiError>(&raw)
+                .map(|e| e.error.message)
+                .unwrap_or(raw);
+            warn!(status = %status, error = %msg, "Anthropic API error (tools)");
+            return Err(HarnessError::Api { status: status.as_u16(), body: msg });
+        }
+
+        let api_resp: ApiResponse = resp
+            .json()
+            .await
+            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+
+        Ok(api_resp_to_turn(api_resp))
+    }
+
+    /// Real SSE streaming — yields text deltas as they arrive from the Anthropic API.
+    async fn stream(&self, messages: &[Message]) -> Result<TokenStream> {
+        let (system_prompt, api_messages) = self.build_api_messages(messages)?;
+
+        let body = ApiStreamRequest {
+            model: &self.model,
+            max_tokens: self.max_tokens,
+            messages: api_messages,
+            system: system_prompt,
+            stream: true,
+        };
+
+        debug!(model = %self.model, "opening SSE stream to Anthropic API");
+
+        let resp = self
+            .client
+            .post(ANTHROPIC_API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let raw = resp.text().await.unwrap_or_default();
+            let msg = serde_json::from_str::<ApiError>(&raw)
+                .map(|e| e.error.message)
+                .unwrap_or(raw);
+            warn!(status = %status, error = %msg, "Anthropic SSE error");
+            return Err(HarnessError::Api { status: status.as_u16(), body: msg });
+        }
+
+        let (tx, rx) = futures::channel::mpsc::channel::<Result<StreamChunk>>(64);
+        let mut byte_stream = resp.bytes_stream();
+
+        tokio::spawn(async move {
+            let mut tx = tx;
+            let mut buf = String::new();
+
+            while let Some(item) = byte_stream.next().await {
+                match item {
+                    Err(e) => {
+                        let _ = tx.try_send(Err(HarnessError::Provider(e.to_string())));
+                        return;
+                    }
+                    Ok(bytes) => {
+                        buf.push_str(&String::from_utf8_lossy(&bytes));
+
+                        // Drain complete lines from the buffer.
+                        loop {
+                            match buf.find('\n') {
+                                None => break,
+                                Some(pos) => {
+                                    let line: String = buf.drain(..=pos).collect();
+                                    let line = line.trim_end();
+
+                                    if let Some(data) = line.strip_prefix("data: ") {
+                                        if let Ok(v) =
+                                            serde_json::from_str::<serde_json::Value>(data)
+                                        {
+                                            match v["type"].as_str().unwrap_or("") {
+                                                "content_block_delta" => {
+                                                    if v["delta"]["type"] == "text_delta" {
+                                                        if let Some(text) =
+                                                            v["delta"]["text"].as_str()
+                                                        {
+                                                            if tx
+                                                                .try_send(Ok(StreamChunk {
+                                                                    delta: text.to_string(),
+                                                                    done: false,
+                                                                }))
+                                                                .is_err()
+                                                            {
+                                                                return;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                "message_stop" => {
+                                                    let _ = tx.try_send(Ok(StreamChunk {
+                                                        delta: String::new(),
+                                                        done: true,
+                                                    }));
+                                                    return;
+                                                }
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Stream ended without explicit message_stop.
+            let _ = tx.try_send(Ok(StreamChunk { delta: String::new(), done: true }));
+        });
+
+        Ok(Box::pin(rx))
     }
 }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -20,3 +20,24 @@ impl ToolHandler for EchoTool {
         ToolOutput::ok(msg)
     }
 }
+
+/// Read the UTF-8 contents of a file at a given path.
+pub struct ReadFileTool;
+
+#[async_trait]
+impl ToolHandler for ReadFileTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::simple("read_file", "Read the UTF-8 contents of a file", &["path"])
+    }
+
+    async fn call(&self, input: Value) -> ToolOutput {
+        let path = match input["path"].as_str() {
+            Some(p) => p.to_string(),
+            None => return ToolOutput::err("missing required field: path"),
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => ToolOutput::ok(contents),
+            Err(e) => ToolOutput::err(format!("read_file failed for {path}: {e}")),
+        }
+    }
+}

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -1,3 +1,4 @@
+use harness_core::provider::ToolDef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -26,6 +27,15 @@ impl ToolSchema {
                 "properties": properties,
                 "required": required_strings,
             }),
+        }
+    }
+
+    /// Convert to a `ToolDef` for passing to provider methods.
+    pub fn to_def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: self.input_schema.clone(),
         }
     }
 


### PR DESCRIPTION
## Summary

- **ClaudeProvider**: real Anthropic SSE streaming via `futures::channel::mpsc` + spawned tokio task; yields `StreamChunk` deltas in real time
- **ClaudeProvider**: `complete_with_tools()` now parses full `tool_use` content blocks
- **harness run**: new `--stream` flag streams tokens to stdout as they arrive
- **harness eval**: new subcommand reads a JSONL test suite (`{goal, expected, label?}`) and reports pass/fail per case with `--fail-fast` support

## Test plan

- [x] `cargo check --workspace` passes
- [x] All 10 tests pass (`cargo test --workspace`)
- [ ] Manual smoke: `harness run --stream --goal "hello"` (requires ANTHROPIC_API_KEY)
- [ ] Manual smoke: `harness eval --cases cases.jsonl --provider echo`

Part of ANGA-70 Phase 3: streaming + eval