### PR TITLE
docs: expand README with architecture, roadmap, and contributor policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to paperclip-harness
+
+Thanks for your interest. This document covers everything you need to contribute effectively.
+
+## Before you start
+
+This project is developed primarily by AI agents under [Paperclip](https://paperclip.ing) governance, with a human board providing direction and review. External contributions are welcome — but the bar is high. We prefer fewer, better PRs over volume.
+
+**Always open an issue before writing code for a non-trivial change.** It avoids wasted effort and lets us tell you whether the change fits the roadmap.
+
+## Setting up
+
+```bash
+git clone https://github.com/anhermon/paperclip-harness
+cd paperclip-harness
+cargo build          # verify dependencies resolve
+cargo test           # should be green — uses echo provider, no API key needed
+```
+
+Minimum toolchain: **Rust 1.75** (see `Cargo.toml` `rust-version`).
+
+## What to work on
+
+Good first targets:
+
+- Items marked `good first issue` in the [issue tracker](https://github.com/anhermon/paperclip-harness/issues)
+- Test coverage gaps
+- Documentation improvements
+
+Things to avoid proposing unless you've discussed first:
+
+- New LLM provider integrations (we have a defined provider trait; new backends are welcome but need discussion)
+- Changes to the core `Provider` or `ToolRegistry` traits (these affect everything)
+- New crates / workspace members
+- Anything touching `unsafe`
+
+## Pull request checklist
+
+Before opening a PR, confirm:
+
+- [ ] `cargo test` passes locally
+- [ ] `cargo clippy -- -D warnings` is clean
+- [ ] `cargo fmt` has been run
+- [ ] New behaviour has a test (using `EchoProvider` where possible)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] The PR description explains *why*, not just *what*
+
+## Commit format
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer]
+Co-Authored-By: <name> <email>   ← required for AI-agent commits
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`
+
+Scopes: `core`, `tools`, `memory`, `cli`, `task`, `orchestrator`, `ui`, `deps`
+
+## Branching model
+
+```
+master          ← stable, protected
+  feat/*        ← new features
+  fix/*         ← bug fixes
+  docs/*        ← docs only
+  chore/*       ← deps / CI / tooling
+```
+
+All branches cut from `master`. Squash-merge preferred for feat/* and fix/*; merge commit for larger milestones.
+
+## Testing philosophy
+
+- The `EchoProvider` exists so the full tool/memory/CLI pipeline can be tested without hitting an API.
+- Unit tests live next to the code they test (`#[cfg(test)]` modules).
+- Integration tests go in `tests/` at the crate root.
+- Do not mock the database. Use an in-memory SQLite URL (`sqlite::memory:`) instead.
+
+## AI-agent contributors
+
+Agents committing to this repo via Paperclip must:
+
+1. Include `Co-Authored-By: Paperclip <noreply@paperclip.ing>` in every commit.
+2. Reference the Paperclip issue ID in the PR description (e.g. `Closes ANGA-70`).
+3. Not push directly to `master` — always via a reviewed PR.
+
+## Questions
+
+Open a [GitHub Discussion](https://github.com/anhermon/paperclip-harness/discussions) for open-ended questions. Use issues for concrete bugs or proposals.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,222 @@
 # paperclip-harness
 
-A Rust-native, provider-agnostic agent harness.
+> A world-class, Rust-native agent harness. One binary. Any LLM. Full autonomy with comfortable human override.
 
-> **Status:** v0 — single-turn agent loop with Claude, SQLite memory, tool registry.
+**Status:** Phase 3 in progress — v0 single-turn loop shipped; sub-agent orchestration and self-evolution next.
 
-## Quick start
+---
 
-```bash
-export ANTHROPIC_API_KEY=sk-...
-cargo run -- run --goal "What is 2+2?"
+## Vision
 
-# Or use the echo provider (no API key needed)
-cargo run -- run --provider echo --goal "hello"
+Most agent frameworks bolt autonomy onto a chat loop. `paperclip-harness` is designed from first principles as a **self-bootstrapping agent OS**:
 
-# Check config
-cargo run -- config --check
+1. You run the binary, configure your LLM provider, and describe your goals.
+2. The agent plans its first tasks, builds the skills it needs, and spawns sub-agents to execute them.
+3. After each session it reflects, critiques its own outputs, and evolves its prompts and skills.
+4. You watch, approve, and redirect via a Paperclip-compatible control plane — intervening only when you want to.
+
+The result is a system that compounds in capability over time, learns from every session, and stays legible to its operators.
+
+---
+
+## Architecture
+
+Eight layers, bottom-up:
+
+```
+┌──────────────────────────────────────────────────┐
+│  8. Control Plane / UI                           │
+│     WebSocket gateway · ratatui TUI              │
+│     Paperclip API compatibility                  │
+├──────────────────────────────────────────────────┤
+│  7. Self-Evolution Engine                        │
+│     observe → critique → generate → validate     │
+│     5-gate minority-veto · prompt/skill rollback │
+├──────────────────────────────────────────────────┤
+│  6. Memory System                                │
+│     SQLite + FTS5 episodic · SQLite-vec semantic │
+│     PARA-structured knowledge base               │
+├──────────────────────────────────────────────────┤
+│  5. Sub-agent Orchestration                      │
+│     tokio tasks + RPC · session-type sandbox     │
+│     worktree isolation for coding agents         │
+├──────────────────────────────────────────────────┤
+│  4. Task Management                              │
+│     issue/task lifecycle · planning step         │
+│     graph-based DAG with checkpointing           │
+├──────────────────────────────────────────────────┤
+│  3. Tool & Skill System                          │
+│     registry dispatch · YAML/TOML + Rust skills  │
+│     dynamic MCP registration · WASM hot-reload   │
+├──────────────────────────────────────────────────┤
+│  2. Agent Core                                   │
+│     provider-agnostic LLM trait                  │
+│     async turn loop · capability-gated (type-state)│
+├──────────────────────────────────────────────────┤
+│  1. Bootstrap Layer                              │
+│     provider config at first run                 │
+│     context/goal elicitation · self-bootstraps   │
+└──────────────────────────────────────────────────┘
 ```
 
-## Workspace layout
+### Crate layout
 
 ```
 crates/
-├── core/     # Provider trait, message types, config, session
-├── tools/    # Tool registry, schema validation, built-in tools
-├── memory/   # SQLite episodic memory (sqlx + FTS5)
-└── cli/      # clap CLI: harness run / config / memory
+├── core/      Provider trait, message types, config, session, turn loop
+├── tools/     Tool registry, serde_json schema validation, built-in tools
+├── memory/    SQLite episodic memory (sqlx + FTS5), semantic recall (sqlite-vec)
+├── cli/       clap derive CLI: harness run / config / memory / eval
+├── task/      (planned) Task DAG, planning step, checkpointing
+├── orchestrator/ (planned) Sub-agent spawn/manage via tokio RPC
+└── ui/        (planned) ratatui TUI + WebSocket control plane
 ```
+
+---
+
+## Quick Start
+
+```bash
+# Requires Rust 1.75+
+git clone https://github.com/anhermon/paperclip-harness
+cd paperclip-harness
+
+# Run with Claude (default)
+export ANTHROPIC_API_KEY=sk-ant-...
+cargo run -- run --goal "Summarise the current directory"
+
+# Run with the echo provider — no API key, great for testing
+cargo run -- run --provider echo --goal "hello"
+
+# Check your config
+cargo run -- config --check
+
+# Search episodic memory
+cargo run -- memory search "yesterday's goal"
+```
+
+---
 
 ## Providers
 
-| Backend  | Env var             | Notes                          |
-|----------|---------------------|-------------------------------|
-| `claude` | `ANTHROPIC_API_KEY` | Default. claude-sonnet-4-5     |
-| `echo`   | —                   | Echoes input, useful for tests |
+| Backend  | Env var             | Notes                                    |
+|----------|---------------------|------------------------------------------|
+| `claude` | `ANTHROPIC_API_KEY` | Default. Uses `claude-sonnet-4-5`.       |
+| `echo`   | —                   | Mirrors input back. Zero cost, CI-safe.  |
+| `openai` | `OPENAI_API_KEY`    | Planned — Phase 4.                       |
+| `local`  | —                   | Ollama / llama.cpp. Planned — Phase 4.   |
+
+Adding a provider means implementing one async trait in `crates/core/src/providers/`.
+
+---
 
 ## Memory
 
-Episodes are stored in `~/.paperclip/harness/memory.db` (SQLite).
-Full-text search via FTS5: `harness memory search "my query"`.
+Episodes are stored in `~/.paperclip/harness/memory.db` (SQLite + FTS5).
+
+```bash
+harness memory search "rust async"    # full-text search
+harness memory list --limit 20        # recent episodes
+harness memory purge --before 30d     # clean up old entries
+```
+
+Semantic recall via `sqlite-vec` is planned for Phase 3.
+
+---
+
+## Roadmap
+
+| Phase | Status       | Scope |
+|-------|-------------|-------|
+| 1     | ✅ done      | Claude Code fork & architecture study |
+| 2     | ✅ done      | Rust dev skills, Cargo workspace, provider trait, tool registry, SQLite memory, CLI |
+| 3     | 🔄 in progress | Tool call loop, streaming, `harness eval`, task DAG, planning step |
+| 4     | planned     | Sub-agent orchestration (tokio RPC, session-type sandbox, worktree isolation) |
+| 5     | planned     | Self-evolution engine (5-gate validate, prompt/skill versioning, rollback) |
+| 6     | planned     | Control plane: WebSocket gateway, ratatui TUI, Paperclip API adapter, open-source release |
+
+Detailed per-phase breakdown lives in the [ANGA-70 plan](http://localhost:3100/ANGA/issues/ANGA-70#document-plan).
+
+---
+
+## Reference Projects
+
+This harness is informed by studying the best open-source agent frameworks:
+
+| Project | Key pattern adopted |
+|---------|---------------------|
+| [hermes-agent](https://github.com/nousresearch/hermes-agent) | Skills as learnable/portable units; closed RL learning loop |
+| [opencode](https://github.com/anomalyco/opencode) | Type-state capability gating; client/server split |
+| [deepagents](https://github.com/langchain-ai/deepagents) | Explicit planning step; graph-based task DAG with checkpointing |
+| [openclaw](https://github.com/openclaw/openclaw) | WebSocket control plane; enum session type as compile-time policy |
+| [codex](https://github.com/openai/codex) | Multi-surface single-backend deployment model |
+| [phantom](https://github.com/ghostwright/phantom) | 5-gate self-evolution engine with minority veto; dynamic tool registry |
+| Claude Code | Tool registry; skill system; MCP integration; hook system |
+
+---
+
+## Contributing
+
+### Who this is for
+
+This project is primarily developed by AI agents operating under [Paperclip](https://paperclip.ing) governance, with human oversight from the project board. External contributors are welcome, but should read this section carefully.
+
+### Ground rules
+
+- **Issues before PRs.** Open an issue to discuss intent before investing in an implementation. Large PRs without prior discussion will likely be closed.
+- **One concern per PR.** Keep changes focused. A PR that mixes a bug fix with a refactor and a new feature will be asked to split.
+- **Tests are not optional.** Every new behaviour needs a test. The echo provider exists precisely so tests run without an API key.
+- **Unsafe code requires justification.** If you reach for `unsafe`, explain why in the PR body. Most use cases don't need it.
+- **No breaking changes without a plan.** If you need to change a public API, open a discussion issue first with a migration path.
+
+### Development workflow
+
+```bash
+# Run the full test suite
+cargo test
+
+# Type-check without building (fast feedback)
+cargo check
+
+# Lint
+cargo clippy -- -D warnings
+
+# Format
+cargo fmt --check
+```
+
+### Commit style
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(memory): add FTS5 phrase search support
+fix(cli): handle missing config file gracefully
+docs(readme): expand architecture section
+chore(deps): bump sqlx to 0.8
+```
+
+AI-agent commits must include:
+```
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```
+
+### Branching
+
+| Branch pattern | Purpose |
+|----------------|---------|
+| `master`       | Stable. Protected. Only merges from reviewed PRs. |
+| `feat/*`       | New features. Branch from `master`. |
+| `fix/*`        | Bug fixes. |
+| `docs/*`       | Documentation only. |
+| `chore/*`      | Deps, CI, tooling. |
+
+### Code of conduct
+
+Be direct, be kind, be useful. We don't have a lengthy CoC — just don't be a jerk, and focus on the work.
+
+---
 
 ## License
 
-MIT OR Apache-2.0
+Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE) at your option.


### PR DESCRIPTION
## Summary
- Expanded README with full architecture overview, project roadmap, and contributor policy
- Adds CONTRIBUTING.md with branch strategy, commit requirements, and dev workflow
- Foundation documentation for the rust-harness OSS project

## Context
Part of ANGA-264 cadence push. Branch `docs/readme-and-contributing` (commit `10f4e0f`) is ready for review.

Closes ANGA-266

## Test plan
- [ ] Review README for accuracy and completeness
- [ ] Review CONTRIBUTING.md for contributor-friendliness
- [ ] Merge to main after board approval

> Note: spec referenced `master` but remote default is `main`; opening against `dev` per branch strategy.

?? Generated with Claude Code
Co-Authored-By: Paperclip <noreply@paperclip.ing>