### PR TITLE
ci: add GitHub Actions workflow for build, test, and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: Build, Test, Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with stable Rust toolchain
- Triggers on push/PR to `main` and `dev` branches
- Jobs: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`
- Includes cargo registry caching for faster runs

## Context
Part of ANGA-264 cadence push. Required by board directive to have CI running before merging Rust code.

Closes ANGA-265

## Test plan
- [ ] CI workflow triggers on PR open
- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes

?? Generated with Claude Code
Co-Authored-By: Paperclip <noreply@paperclip.ing>