### PR TITLE
feat(v3): sub-agent spawning via spawn_subagent tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: Build, Test, Clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to paperclip-harness
+
+Thanks for your interest. This document covers everything you need to contribute effectively.
+
+## Before you start
+
+This project is developed primarily by AI agents under [Paperclip](https://paperclip.ing) governance, with a human board providing direction and review. External contributions are welcome — but the bar is high. We prefer fewer, better PRs over volume.
+
+**Always open an issue before writing code for a non-trivial change.** It avoids wasted effort and lets us tell you whether the change fits the roadmap.
+
+## Setting up
+
+```bash
+git clone https://github.com/anhermon/paperclip-harness
+cd paperclip-harness
+cargo build          # verify dependencies resolve
+cargo test           # should be green — uses echo provider, no API key needed
+```
+
+Minimum toolchain: **Rust 1.75** (see `Cargo.toml` `rust-version`).
+
+## What to work on
+
+Good first targets:
+
+- Items marked `good first issue` in the [issue tracker](https://github.com/anhermon/paperclip-harness/issues)
+- Test coverage gaps
+- Documentation improvements
+
+Things to avoid proposing unless you've discussed first:
+
+- New LLM provider integrations (we have a defined provider trait; new backends are welcome but need discussion)
+- Changes to the core `Provider` or `ToolRegistry` traits (these affect everything)
+- New crates / workspace members
+- Anything touching `unsafe`
+
+## Pull request checklist
+
+Before opening a PR, confirm:
+
+- [ ] `cargo test` passes locally
+- [ ] `cargo clippy -- -D warnings` is clean
+- [ ] `cargo fmt` has been run
+- [ ] New behaviour has a test (using `EchoProvider` where possible)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] The PR description explains *why*, not just *what*
+
+## Commit format
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer]
+Co-Authored-By: <name> <email>   ← required for AI-agent commits
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`
+
+Scopes: `core`, `tools`, `memory`, `cli`, `task`, `orchestrator`, `ui`, `deps`
+
+## Branching model
+
+```
+master          ← stable, protected
+  feat/*        ← new features
+  fix/*         ← bug fixes
+  docs/*        ← docs only
+  chore/*       ← deps / CI / tooling
+```
+
+All branches cut from `master`. Squash-merge preferred for feat/* and fix/*; merge commit for larger milestones.
+
+## Testing philosophy
+
+- The `EchoProvider` exists so the full tool/memory/CLI pipeline can be tested without hitting an API.
+- Unit tests live next to the code they test (`#[cfg(test)]` modules).
+- Integration tests go in `tests/` at the crate root.
+- Do not mock the database. Use an in-memory SQLite URL (`sqlite::memory:`) instead.
+
+## AI-agent contributors
+
+Agents committing to this repo via Paperclip must:
+
+1. Include `Co-Authored-By: Paperclip <noreply@paperclip.ing>` in every commit.
+2. Reference the Paperclip issue ID in the PR description (e.g. `Closes ANGA-70`).
+3. Not push directly to `master` — always via a reviewed PR.
+
+## Questions
+
+Open a [GitHub Discussion](https://github.com/anhermon/paperclip-harness/discussions) for open-ended questions. Use issues for concrete bugs or proposals.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,222 @@
 # paperclip-harness
 
-A Rust-native, provider-agnostic agent harness.
+> A world-class, Rust-native agent harness. One binary. Any LLM. Full autonomy with comfortable human override.
 
-> **Status:** v0 — single-turn agent loop with Claude, SQLite memory, tool registry.
+**Status:** Phase 3 in progress — v0 single-turn loop shipped; sub-agent orchestration and self-evolution next.
 
-## Quick start
+---
 
-```bash
-export ANTHROPIC_API_KEY=sk-...
-cargo run -- run --goal "What is 2+2?"
+## Vision
 
-# Or use the echo provider (no API key needed)
-cargo run -- run --provider echo --goal "hello"
+Most agent frameworks bolt autonomy onto a chat loop. `paperclip-harness` is designed from first principles as a **self-bootstrapping agent OS**:
 
-# Check config
-cargo run -- config --check
+1. You run the binary, configure your LLM provider, and describe your goals.
+2. The agent plans its first tasks, builds the skills it needs, and spawns sub-agents to execute them.
+3. After each session it reflects, critiques its own outputs, and evolves its prompts and skills.
+4. You watch, approve, and redirect via a Paperclip-compatible control plane — intervening only when you want to.
+
+The result is a system that compounds in capability over time, learns from every session, and stays legible to its operators.
+
+---
+
+## Architecture
+
+Eight layers, bottom-up:
+
+```
+┌──────────────────────────────────────────────────┐
+│  8. Control Plane / UI                           │
+│     WebSocket gateway · ratatui TUI              │
+│     Paperclip API compatibility                  │
+├──────────────────────────────────────────────────┤
+│  7. Self-Evolution Engine                        │
+│     observe → critique → generate → validate     │
+│     5-gate minority-veto · prompt/skill rollback │
+├──────────────────────────────────────────────────┤
+│  6. Memory System                                │
+│     SQLite + FTS5 episodic · SQLite-vec semantic │
+│     PARA-structured knowledge base               │
+├──────────────────────────────────────────────────┤
+│  5. Sub-agent Orchestration                      │
+│     tokio tasks + RPC · session-type sandbox     │
+│     worktree isolation for coding agents         │
+├──────────────────────────────────────────────────┤
+│  4. Task Management                              │
+│     issue/task lifecycle · planning step         │
+│     graph-based DAG with checkpointing           │
+├──────────────────────────────────────────────────┤
+│  3. Tool & Skill System                          │
+│     registry dispatch · YAML/TOML + Rust skills  │
+│     dynamic MCP registration · WASM hot-reload   │
+├──────────────────────────────────────────────────┤
+│  2. Agent Core                                   │
+│     provider-agnostic LLM trait                  │
+│     async turn loop · capability-gated (type-state)│
+├──────────────────────────────────────────────────┤
+│  1. Bootstrap Layer                              │
+│     provider config at first run                 │
+│     context/goal elicitation · self-bootstraps   │
+└──────────────────────────────────────────────────┘
 ```
 
-## Workspace layout
+### Crate layout
 
 ```
 crates/
-├── core/     # Provider trait, message types, config, session
-├── tools/    # Tool registry, schema validation, built-in tools
-├── memory/   # SQLite episodic memory (sqlx + FTS5)
-└── cli/      # clap CLI: harness run / config / memory
+├── core/      Provider trait, message types, config, session, turn loop
+├── tools/     Tool registry, serde_json schema validation, built-in tools
+├── memory/    SQLite episodic memory (sqlx + FTS5), semantic recall (sqlite-vec)
+├── cli/       clap derive CLI: harness run / config / memory / eval
+├── task/      (planned) Task DAG, planning step, checkpointing
+├── orchestrator/ (planned) Sub-agent spawn/manage via tokio RPC
+└── ui/        (planned) ratatui TUI + WebSocket control plane
 ```
+
+---
+
+## Quick Start
+
+```bash
+# Requires Rust 1.75+
+git clone https://github.com/anhermon/paperclip-harness
+cd paperclip-harness
+
+# Run with Claude (default)
+export ANTHROPIC_API_KEY=sk-ant-...
+cargo run -- run --goal "Summarise the current directory"
+
+# Run with the echo provider — no API key, great for testing
+cargo run -- run --provider echo --goal "hello"
+
+# Check your config
+cargo run -- config --check
+
+# Search episodic memory
+cargo run -- memory search "yesterday's goal"
+```
+
+---
 
 ## Providers
 
-| Backend  | Env var             | Notes                          |
-|----------|---------------------|-------------------------------|
-| `claude` | `ANTHROPIC_API_KEY` | Default. claude-sonnet-4-5     |
-| `echo`   | —                   | Echoes input, useful for tests |
+| Backend  | Env var             | Notes                                    |
+|----------|---------------------|------------------------------------------|
+| `claude` | `ANTHROPIC_API_KEY` | Default. Uses `claude-sonnet-4-5`.       |
+| `echo`   | —                   | Mirrors input back. Zero cost, CI-safe.  |
+| `openai` | `OPENAI_API_KEY`    | Planned — Phase 4.                       |
+| `local`  | —                   | Ollama / llama.cpp. Planned — Phase 4.   |
+
+Adding a provider means implementing one async trait in `crates/core/src/providers/`.
+
+---
 
 ## Memory
 
-Episodes are stored in `~/.paperclip/harness/memory.db` (SQLite).
-Full-text search via FTS5: `harness memory search "my query"`.
+Episodes are stored in `~/.paperclip/harness/memory.db` (SQLite + FTS5).
+
+```bash
+harness memory search "rust async"    # full-text search
+harness memory list --limit 20        # recent episodes
+harness memory purge --before 30d     # clean up old entries
+```
+
+Semantic recall via `sqlite-vec` is planned for Phase 3.
+
+---
+
+## Roadmap
+
+| Phase | Status       | Scope |
+|-------|-------------|-------|
+| 1     | ✅ done      | Claude Code fork & architecture study |
+| 2     | ✅ done      | Rust dev skills, Cargo workspace, provider trait, tool registry, SQLite memory, CLI |
+| 3     | 🔄 in progress | Tool call loop, streaming, `harness eval`, task DAG, planning step |
+| 4     | planned     | Sub-agent orchestration (tokio RPC, session-type sandbox, worktree isolation) |
+| 5     | planned     | Self-evolution engine (5-gate validate, prompt/skill versioning, rollback) |
+| 6     | planned     | Control plane: WebSocket gateway, ratatui TUI, Paperclip API adapter, open-source release |
+
+Detailed per-phase breakdown lives in the [ANGA-70 plan](http://localhost:3100/ANGA/issues/ANGA-70#document-plan).
+
+---
+
+## Reference Projects
+
+This harness is informed by studying the best open-source agent frameworks:
+
+| Project | Key pattern adopted |
+|---------|---------------------|
+| [hermes-agent](https://github.com/nousresearch/hermes-agent) | Skills as learnable/portable units; closed RL learning loop |
+| [opencode](https://github.com/anomalyco/opencode) | Type-state capability gating; client/server split |
+| [deepagents](https://github.com/langchain-ai/deepagents) | Explicit planning step; graph-based task DAG with checkpointing |
+| [openclaw](https://github.com/openclaw/openclaw) | WebSocket control plane; enum session type as compile-time policy |
+| [codex](https://github.com/openai/codex) | Multi-surface single-backend deployment model |
+| [phantom](https://github.com/ghostwright/phantom) | 5-gate self-evolution engine with minority veto; dynamic tool registry |
+| Claude Code | Tool registry; skill system; MCP integration; hook system |
+
+---
+
+## Contributing
+
+### Who this is for
+
+This project is primarily developed by AI agents operating under [Paperclip](https://paperclip.ing) governance, with human oversight from the project board. External contributors are welcome, but should read this section carefully.
+
+### Ground rules
+
+- **Issues before PRs.** Open an issue to discuss intent before investing in an implementation. Large PRs without prior discussion will likely be closed.
+- **One concern per PR.** Keep changes focused. A PR that mixes a bug fix with a refactor and a new feature will be asked to split.
+- **Tests are not optional.** Every new behaviour needs a test. The echo provider exists precisely so tests run without an API key.
+- **Unsafe code requires justification.** If you reach for `unsafe`, explain why in the PR body. Most use cases don't need it.
+- **No breaking changes without a plan.** If you need to change a public API, open a discussion issue first with a migration path.
+
+### Development workflow
+
+```bash
+# Run the full test suite
+cargo test
+
+# Type-check without building (fast feedback)
+cargo check
+
+# Lint
+cargo clippy -- -D warnings
+
+# Format
+cargo fmt --check
+```
+
+### Commit style
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(memory): add FTS5 phrase search support
+fix(cli): handle missing config file gracefully
+docs(readme): expand architecture section
+chore(deps): bump sqlx to 0.8
+```
+
+AI-agent commits must include:
+```
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```
+
+### Branching
+
+| Branch pattern | Purpose |
+|----------------|---------|
+| `master`       | Stable. Protected. Only merges from reviewed PRs. |
+| `feat/*`       | New features. Branch from `master`. |
+| `fix/*`        | Bug fixes. |
+| `docs/*`       | Documentation only. |
+| `chore/*`      | Deps, CI, tooling. |
+
+### Code of conduct
+
+Be direct, be kind, be useful. We don't have a lengthy CoC — just don't be a jerk, and focus on the work.
+
+---
 
 ## License
 
-MIT OR Apache-2.0
+Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE) at your option.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,3 +22,7 @@ tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ harness-core = { workspace = true }
 harness-tools = { workspace = true }
 harness-memory = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use harness_core::{
     config::Config,
     message::{ContentBlock, Message, MessageContent, Role, StopReason},
@@ -7,8 +8,11 @@ use harness_core::{
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
-use harness_tools::{ToolRegistry, builtin::EchoTool};
+use harness_tools::{ToolRegistry, builtin::{EchoTool, ReadFileTool, SpawnSubagentTool}};
 use tracing::{debug, info, warn};
+
+/// Maximum sub-agent nesting depth to prevent infinite recursion.
+const MAX_SUBAGENT_DEPTH: usize = 4;
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
@@ -16,19 +20,43 @@ pub struct Agent {
     memory: Arc<MemoryDb>,
     tools: ToolRegistry,
     config: Config,
+    /// Nesting depth: 0 for the root agent, incremented for each sub-agent.
+    depth: usize,
 }
 
 impl Agent {
     pub fn new(provider: Arc<dyn Provider>, memory: Arc<MemoryDb>, config: Config) -> Self {
+        Self::new_with_depth(provider, memory, config, 0)
+    }
+
+    fn new_with_depth(
+        provider: Arc<dyn Provider>,
+        memory: Arc<MemoryDb>,
+        config: Config,
+        depth: usize,
+    ) -> Self {
         let tools = ToolRegistry::new();
         tools.register(EchoTool);
-        Self { provider, memory, tools, config }
+        tools.register(ReadFileTool);
+        tools.register(SpawnSubagentTool);
+        Self { provider, memory, tools, config, depth }
     }
 
     /// Run until the agent signals completion or max iterations reached.
-    pub async fn run(&self, goal: &str) -> anyhow::Result<Session> {
+    ///
+    /// Returns a `BoxFuture` so recursive sub-agent calls compile without infinite types.
+    pub fn run<'a>(&'a self, goal: &'a str) -> BoxFuture<'a, anyhow::Result<Session>> {
+        Box::pin(self.run_inner(goal))
+    }
+
+    async fn run_inner(&self, goal: &str) -> anyhow::Result<Session> {
         let mut session = Session::new(goal);
-        info!(session_id = %session.id, goal = %goal, "starting session");
+        info!(
+            session_id = %session.id,
+            depth = self.depth,
+            goal = %goal,
+            "starting session"
+        );
 
         // Build initial messages
         let mut messages: Vec<Message> = Vec::new();
@@ -60,7 +88,7 @@ impl Agent {
             }
 
             session.iteration += 1;
-            debug!(iteration = session.iteration, "agent turn");
+            debug!(iteration = session.iteration, depth = self.depth, "agent turn");
 
             let response = self.provider.complete_with_tools(&messages, &tool_defs).await?;
 
@@ -68,6 +96,7 @@ impl Agent {
             info!(
                 tokens_out = response.usage.output_tokens,
                 stop_reason = ?response.stop_reason,
+                depth = self.depth,
                 "← {}",
                 &preview[..preview.len().min(120)]
             );
@@ -113,8 +142,23 @@ impl Agent {
                     // Execute each tool and collect result blocks.
                     let mut result_blocks: Vec<ContentBlock> = Vec::new();
                     for (tool_use_id, name, input) in tool_calls {
-                        info!(tool = %name, "→ calling tool");
-                        let output = self.tools.call(&name, input).await;
+                        info!(tool = %name, depth = self.depth, "→ calling tool");
+                        let output = if name == "spawn_subagent" {
+                            let sub_goal = input["goal"].as_str().unwrap_or("").to_string();
+                            let context = input
+                                .get("context")
+                                .and_then(|c| c.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            info!(sub_goal = %sub_goal, depth = self.depth, "spawning sub-agent");
+                            match self.spawn_subagent(&sub_goal, &context).await {
+                                Ok(result) => harness_tools::ToolOutput::ok(result),
+                                Err(e) => harness_tools::ToolOutput::err(format!("sub-agent error: {e}")),
+                            }
+                        } else {
+                            self.tools.call(&name, input).await
+                        };
+
                         if output.is_error {
                             warn!(tool = %name, "tool returned error: {}", output.content);
                         }
@@ -136,6 +180,48 @@ impl Agent {
         }
 
         Ok(session)
+    }
+
+    /// Spawn a nested sub-agent to handle a delegated goal.
+    ///
+    /// Returns the sub-agent's final response text, or an error if depth
+    /// exceeds [`MAX_SUBAGENT_DEPTH`].
+    async fn spawn_subagent(&self, goal: &str, context: &str) -> anyhow::Result<String> {
+        if self.depth >= MAX_SUBAGENT_DEPTH {
+            return Err(anyhow::anyhow!(
+                "sub-agent depth limit ({MAX_SUBAGENT_DEPTH}) reached — cannot spawn further"
+            ));
+        }
+
+        let full_goal = if context.is_empty() {
+            goal.to_string()
+        } else {
+            format!("{context}\n\n{goal}")
+        };
+
+        let sub_agent = Agent::new_with_depth(
+            Arc::clone(&self.provider),
+            Arc::clone(&self.memory),
+            self.config.clone(),
+            self.depth + 1,
+        );
+
+        let session = sub_agent.run(&full_goal).await?;
+
+        let result = session
+            .messages
+            .last()
+            .and_then(|m| m.text())
+            .unwrap_or("(sub-agent produced no output)")
+            .to_string();
+
+        info!(
+            depth = self.depth,
+            result_len = result.len(),
+            "sub-agent completed"
+        );
+
+        Ok(result)
     }
 }
 
@@ -242,6 +328,7 @@ mod tests {
                 r
             },
             config,
+            depth: 0,
         };
 
         let session = agent.run("test goal").await.unwrap();
@@ -271,6 +358,7 @@ mod tests {
                 r
             },
             config,
+            depth: 0,
         };
 
         let session = agent.run("loop forever").await.unwrap();
@@ -290,6 +378,7 @@ mod tests {
             memory,
             tools: ToolRegistry::new(),
             config,
+            depth: 0,
         };
 
         let session = agent.run("simple goal").await.unwrap();
@@ -297,5 +386,69 @@ mod tests {
         assert_eq!(session.status, harness_core::session::SessionStatus::Done);
         assert_eq!(session.iteration, 1);
         assert_eq!(session.messages.len(), 1); // only the assistant response
+    }
+
+    #[tokio::test]
+    async fn subagent_spawned_and_returns_result() {
+        // Main agent: spawns a sub-agent, then finishes after seeing the result.
+        // Sub-agent: immediately returns EndTurn with "sub-result".
+        //
+        // ScriptedProvider is shared — responses interleave:
+        //   pop 1 (main): spawn_subagent tool use
+        //   pop 2 (sub):  end_turn "sub-result"
+        //   pop 3 (main): end_turn "main done"
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response(
+                "sa-1",
+                "spawn_subagent",
+                serde_json::json!({"goal": "compute something"}),
+            ),
+            end_turn_response("sub-result"),
+            end_turn_response("main done"),
+        ]));
+
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let agent = Agent::new(provider, memory, config);
+        let session = agent.run("delegate work").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // Last message should be the main agent's final EndTurn response.
+        let last = session.messages.last().unwrap();
+        assert_eq!(last.text(), Some("main done"));
+    }
+
+    #[tokio::test]
+    async fn subagent_depth_limit_returns_error_output() {
+        // Directly test spawn_subagent at max depth returns an Err.
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let deep_agent = Agent::new_with_depth(provider, memory, config, MAX_SUBAGENT_DEPTH);
+        let result = deep_agent.spawn_subagent("unreachable", "").await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("depth limit"), "expected 'depth limit' in: {msg}");
+    }
+
+    #[tokio::test]
+    async fn subagent_with_context_prepends_to_goal() {
+        // Verify that when context is non-empty it is prepended to the goal
+        // by confirming the sub-agent session runs with the combined text.
+        // We use a provider that immediately ends so the sub-agent session completes.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            end_turn_response("context-aware result"),
+        ]));
+        let memory = make_memory().await;
+        let config = make_config(5);
+
+        let provider: Arc<dyn Provider> = provider;
+        let agent = Agent::new_with_depth(Arc::clone(&provider), memory, config, 0);
+        let result = agent.spawn_subagent("do the thing", "background: xyz").await.unwrap();
+
+        assert_eq!(result, "context-aware result");
     }
 }

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use harness_core::{
     config::Config,
-    message::Message,
+    message::{ContentBlock, Message, MessageContent, Role, StopReason},
     provider::Provider,
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
 use harness_tools::{ToolRegistry, builtin::EchoTool};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
@@ -49,6 +49,9 @@ impl Agent {
             self.config.agent.max_iterations
         };
 
+        // Convert registered tool schemas to ToolDefs for the provider.
+        let tool_defs: Vec<_> = self.tools.schemas().iter().map(|s| s.to_def()).collect();
+
         loop {
             if session.iteration >= max_iter {
                 info!("max iterations reached");
@@ -56,28 +59,243 @@ impl Agent {
                 break;
             }
 
+            session.iteration += 1;
             debug!(iteration = session.iteration, "agent turn");
-            let response = self.provider.complete(&messages).await?;
 
-            let text = response.message.text().unwrap_or("").to_string();
-            info!(tokens_out = response.usage.output_tokens, "← {}", &text[..text.len().min(120)]);
+            let response = self.provider.complete_with_tools(&messages, &tool_defs).await?;
 
-            // Record in session
+            let preview = response.message.text().unwrap_or("").to_string();
+            info!(
+                tokens_out = response.usage.output_tokens,
+                stop_reason = ?response.stop_reason,
+                "← {}",
+                &preview[..preview.len().min(120)]
+            );
+
+            // Append assistant message to running history and session log.
+            messages.push(response.message.clone());
             session.push(response.message.clone());
 
-            // Persist to memory
-            let ep = harness_memory::Episode::turn(
-                session.id,
-                "assistant",
-                response.message.text().unwrap_or(""),
-            );
-            self.memory.insert(&ep).await?;
+            match response.stop_reason {
+                StopReason::EndTurn | StopReason::StopSequence | StopReason::MaxTokens => {
+                    // Persist final assistant turn to memory.
+                    let ep = harness_memory::Episode::turn(
+                        session.id,
+                        "assistant",
+                        response.message.text().unwrap_or(""),
+                    );
+                    self.memory.insert(&ep).await?;
+                    session.finish(SessionStatus::Done);
+                    break;
+                }
 
-            // For v0: stop after one assistant turn (no tool loop yet)
-            session.finish(SessionStatus::Done);
-            break;
+                StopReason::ToolUse => {
+                    // Extract every ToolUse block from the assistant response.
+                    let tool_calls: Vec<(String, String, serde_json::Value)> =
+                        match &response.message.content {
+                            MessageContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| {
+                                    if let ContentBlock::ToolUse { id, name, input } = b {
+                                        Some((id.clone(), name.clone(), input.clone()))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                            _ => {
+                                warn!("stop_reason=ToolUse but no ToolUse blocks found; treating as EndTurn");
+                                session.finish(SessionStatus::Done);
+                                break;
+                            }
+                        };
+
+                    // Execute each tool and collect result blocks.
+                    let mut result_blocks: Vec<ContentBlock> = Vec::new();
+                    for (tool_use_id, name, input) in tool_calls {
+                        info!(tool = %name, "→ calling tool");
+                        let output = self.tools.call(&name, input).await;
+                        if output.is_error {
+                            warn!(tool = %name, "tool returned error: {}", output.content);
+                        }
+                        result_blocks.push(ContentBlock::ToolResult {
+                            tool_use_id,
+                            content: output.content,
+                        });
+                    }
+
+                    // Feed results back as a user-role message and continue.
+                    let tool_result_msg = Message {
+                        role: Role::User,
+                        content: MessageContent::Blocks(result_blocks),
+                    };
+                    messages.push(tool_result_msg.clone());
+                    session.push(tool_result_msg);
+                }
+            }
         }
 
         Ok(session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use harness_core::{
+        message::{ContentBlock, MessageContent, Role, StopReason, TurnResponse, Usage},
+        provider::Provider,
+    };
+    use harness_tools::builtin::EchoTool;
+    use std::sync::{Arc, Mutex};
+
+    /// Provider that pops responses from a pre-loaded queue.
+    struct ScriptedProvider {
+        responses: Mutex<Vec<TurnResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<TurnResponse>) -> Self {
+            // Reverse so we can pop from the back in FIFO order.
+            let mut r = responses;
+            r.reverse();
+            Self { responses: Mutex::new(r) }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[harness_core::message::Message],
+        ) -> harness_core::error::Result<TurnResponse> {
+            let mut guard = self.responses.lock().unwrap();
+            Ok(guard.pop().expect("ScriptedProvider ran out of responses"))
+        }
+    }
+
+    fn make_config(max_iterations: usize) -> harness_core::config::Config {
+        let mut cfg = harness_core::config::Config::default();
+        cfg.agent.max_iterations = max_iterations;
+        cfg.agent.system_prompt = None;
+        cfg
+    }
+
+    async fn make_memory() -> Arc<MemoryDb> {
+        Arc::new(MemoryDb::in_memory().await.unwrap())
+    }
+
+    /// Helpers for building TurnResponse values.
+    fn tool_use_response(tool_use_id: &str, tool_name: &str, input: serde_json::Value) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: tool_use_id.to_string(),
+                        name: tool_name.to_string(),
+                        input,
+                    },
+                ]),
+            },
+            stop_reason: StopReason::ToolUse,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    fn end_turn_response(text: &str) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+            },
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            model: "scripted".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_loop_calls_tool_and_continues() {
+        // Turn 1: provider requests an echo tool call.
+        // Turn 2: provider returns EndTurn after seeing the tool result.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("call-1", "echo", serde_json::json!({"message": "ping"})),
+            end_turn_response("done"),
+        ]));
+
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let agent = Agent {
+            provider: provider.clone(),
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // messages: system + user + assistant(tool_use) + user(tool_result) + assistant(end_turn)
+        assert_eq!(session.messages.len(), 3); // assistant(tool_use) + user(tool_result) + assistant(end_turn)
+    }
+
+    #[tokio::test]
+    async fn max_iterations_cap_is_respected() {
+        // Provider always asks for a tool call; cap at 2 iterations.
+        let responses: Vec<TurnResponse> = (0..10)
+            .map(|i| tool_use_response(&format!("c-{i}"), "echo", serde_json::json!({"message": "x"})))
+            .collect();
+
+        let provider = Arc::new(ScriptedProvider::new(responses));
+        let memory = make_memory().await;
+        let config = make_config(2);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config,
+        };
+
+        let session = agent.run("loop forever").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 2);
+    }
+
+    #[tokio::test]
+    async fn end_turn_stops_without_tool_calls() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response("hello")]));
+        let memory = make_memory().await;
+        let config = make_config(5);
+
+        let agent = Agent {
+            provider,
+            memory,
+            tools: ToolRegistry::new(),
+            config,
+        };
+
+        let session = agent.run("simple goal").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert_eq!(session.iteration, 1);
+        assert_eq!(session.messages.len(), 1); // only the assistant response
     }
 }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,7 +1,17 @@
 use async_trait::async_trait;
 use std::pin::Pin;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use crate::{error::Result, message::{Message, TurnResponse}};
+
+/// Lightweight tool definition passed to providers alongside messages.
+/// Mirrors the JSON schema shape expected by Claude / OpenAI tool-calling APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
 
 /// A streaming token chunk from the provider.
 #[derive(Debug, Clone)]
@@ -22,6 +32,16 @@ pub trait Provider: Send + Sync + 'static {
 
     /// Single non-streaming turn: send messages, get back a complete response.
     async fn complete(&self, messages: &[Message]) -> Result<TurnResponse>;
+
+    /// Turn with tool definitions made available to the LLM.
+    /// Defaults to `complete` (tools ignored) for providers that don't support them yet.
+    async fn complete_with_tools(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
+        self.complete(messages).await
+    }
 
     /// Streaming turn: yields token chunks as they arrive.
     /// Default falls back to `complete` and emits one chunk.

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -20,3 +20,24 @@ impl ToolHandler for EchoTool {
         ToolOutput::ok(msg)
     }
 }
+
+/// Read the UTF-8 contents of a file at a given path.
+pub struct ReadFileTool;
+
+#[async_trait]
+impl ToolHandler for ReadFileTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::simple("read_file", "Read the UTF-8 contents of a file", &["path"])
+    }
+
+    async fn call(&self, input: Value) -> ToolOutput {
+        let path = match input["path"].as_str() {
+            Some(p) => p.to_string(),
+            None => return ToolOutput::err("missing required field: path"),
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => ToolOutput::ok(contents),
+            Err(e) => ToolOutput::err(format!("read_file failed for {path}: {e}")),
+        }
+    }
+}

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -21,6 +21,46 @@ impl ToolHandler for EchoTool {
     }
 }
 
+/// Spawn a sub-agent to handle a sub-task.
+///
+/// The actual execution is handled by the [`Agent`] loop in `harness-cli` —
+/// it intercepts calls to this tool name and runs a nested Agent instance.
+/// This struct exists only to declare the schema so the LLM sees the tool.
+pub struct SpawnSubagentTool;
+
+#[async_trait]
+impl ToolHandler for SpawnSubagentTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "spawn_subagent".to_string(),
+            description:
+                "Spawn a sub-agent to handle a delegated sub-task. \
+                 The sub-agent shares the same provider and tool set as the main agent. \
+                 Returns the sub-agent's final response text."
+                    .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "goal": {
+                        "type": "string",
+                        "description": "The goal or task for the sub-agent to accomplish."
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional background context for the sub-agent."
+                    }
+                },
+                "required": ["goal"]
+            }),
+        }
+    }
+
+    async fn call(&self, _input: Value) -> ToolOutput {
+        // The Agent handles spawn_subagent before it reaches the registry.
+        ToolOutput::err("spawn_subagent must be handled by the agent loop, not the registry")
+    }
+}
+
 /// Read the UTF-8 contents of a file at a given path.
 pub struct ReadFileTool;
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -2,5 +2,5 @@ pub mod registry;
 pub mod schema;
 pub mod builtin;
 
-pub use registry::{ToolRegistry, ToolHandler};
+pub use registry::{ToolRegistry, ToolHandler, ToolOutput};
 pub use schema::ToolSchema;

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -1,3 +1,4 @@
+use harness_core::provider::ToolDef;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -26,6 +27,15 @@ impl ToolSchema {
                 "properties": properties,
                 "required": required_strings,
             }),
+        }
+    }
+
+    /// Convert to a `ToolDef` for passing to provider methods.
+    pub fn to_def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: self.input_schema.clone(),
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 5 milestone — agents can now delegate work to nested sub-agents:

- `SpawnSubagentTool` added to `harness_tools::builtin` (schema declaration; execution intercepted by Agent loop)
- `Agent` intercepts `spawn_subagent` tool calls and creates a nested `Agent` at `depth+1`, sharing the same `provider` and `memory` Arc
- `MAX_SUBAGENT_DEPTH=4` guard prevents infinite recursion
- `BoxFuture` used for `run()` to allow recursive async without infinite type sizes
- `ToolOutput` re-exported from `harness_tools` crate root
- 6 integration tests: 3 original + 3 subagent-specific

## Test plan
- [x] `cargo test --workspace` -- 11 tests pass
- [x] `cargo check --workspace` -- no errors
- [ ] CI green