### PR TITLE
chore: add git hooks, cargo aliases, workspace lint config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+check-all = "clippy --workspace --all-targets -- -D warnings"
+test-all = "test --workspace"
+fmt-check = "fmt --all -- --check"

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+MSG=$(cat "$1")
+PATTERN="^(feat|fix|docs|style|refactor|test|chore|ci|perf|revert)(\(.+\))?: .+"
+
+if ! echo "$MSG" | grep -qE "$PATTERN"; then
+  echo "❌ Commit message does not follow Conventional Commits format"
+  echo "   Expected: <type>(<scope>): <description>"
+  echo "   Example: feat(core): add streaming support"
+  echo "   Types: feat, fix, docs, style, refactor, test, chore, ci, perf, revert"
+  exit 1
+fi
+echo "✅ Commit message format OK"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🔍 Running pre-commit checks..."
+
+# Format check
+echo "  → cargo fmt --check"
+cargo fmt --all -- --check
+
+# Clippy lint
+echo "  → cargo clippy"
+cargo clippy --workspace --all-targets -- -D warnings
+
+echo "✅ Pre-commit checks passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🚀 Running pre-push checks..."
+
+# Full test suite
+echo "  → cargo test --workspace"
+cargo test --workspace
+
+echo "✅ Pre-push checks passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,16 @@ Agents committing to this repo via Paperclip must:
 ## Questions
 
 Open a [GitHub Discussion](https://github.com/anhermon/paperclip-harness/discussions) for open-ended questions. Use issues for concrete bugs or proposals.
+
+## Setting Up Dev Hooks
+
+After cloning, install git hooks:
+
+```bash
+bash scripts/setup-hooks.sh
+```
+
+This installs:
+- **pre-commit**: `cargo fmt --check` + `cargo clippy -D warnings`
+- **pre-push**: `cargo test --workspace`
+- **commit-msg**: Enforces Conventional Commits format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,16 @@ strip = true
 [profile.dev]
 opt-level = 0
 debug = true
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unused_imports = "warn"
+unused_variables = "warn"
+dead_code = "warn"
+
+[workspace.lints.clippy]
+all = "warn"
+pedantic = "warn"
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -7,13 +7,14 @@ use harness_core::{
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
-use harness_tools::{ToolRegistry, builtin::EchoTool};
+use harness_tools::{builtin::EchoTool, ToolRegistry};
 use tracing::{debug, info};
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
     provider: Arc<dyn Provider>,
     memory: Arc<MemoryDb>,
+    #[allow(dead_code)]
     tools: ToolRegistry,
     config: Config,
 }
@@ -22,7 +23,12 @@ impl Agent {
     pub fn new(provider: Arc<dyn Provider>, memory: Arc<MemoryDb>, config: Config) -> Self {
         let tools = ToolRegistry::new();
         tools.register(EchoTool);
-        Self { provider, memory, tools, config }
+        Self {
+            provider,
+            memory,
+            tools,
+            config,
+        }
     }
 
     /// Run until the agent signals completion or max iterations reached.
@@ -49,34 +55,35 @@ impl Agent {
             self.config.agent.max_iterations
         };
 
-        loop {
-            if session.iteration >= max_iter {
-                info!("max iterations reached");
-                session.finish(SessionStatus::Done);
-                break;
-            }
-
-            debug!(iteration = session.iteration, "agent turn");
-            let response = self.provider.complete(&messages).await?;
-
-            let text = response.message.text().unwrap_or("").to_string();
-            info!(tokens_out = response.usage.output_tokens, "← {}", &text[..text.len().min(120)]);
-
-            // Record in session
-            session.push(response.message.clone());
-
-            // Persist to memory
-            let ep = harness_memory::Episode::turn(
-                session.id,
-                "assistant",
-                response.message.text().unwrap_or(""),
-            );
-            self.memory.insert(&ep).await?;
-
-            // For v0: stop after one assistant turn (no tool loop yet)
+        if session.iteration >= max_iter {
+            info!("max iterations reached");
             session.finish(SessionStatus::Done);
-            break;
+            return Ok(session);
         }
+
+        debug!(iteration = session.iteration, "agent turn");
+        let response = self.provider.complete(&messages).await?;
+
+        let text = response.message.text().unwrap_or("").to_string();
+        info!(
+            tokens_out = response.usage.output_tokens,
+            "← {}",
+            &text[..text.len().min(120)]
+        );
+
+        // Record in session
+        session.push(response.message.clone());
+
+        // Persist to memory
+        let ep = harness_memory::Episode::turn(
+            session.id,
+            "assistant",
+            response.message.text().unwrap_or(""),
+        );
+        self.memory.insert(&ep).await?;
+
+        // For v0: stop after one assistant turn (no tool loop yet)
+        session.finish(SessionStatus::Done);
 
         Ok(session)
     }

--- a/crates/cli/src/commands/memory.rs
+++ b/crates/cli/src/commands/memory.rs
@@ -36,13 +36,23 @@ pub async fn execute(args: MemoryArgs) -> anyhow::Result<()> {
                 println!("No results for: {query}");
             }
             for ep in results {
-                println!("[{}] {}: {}", ep.created_at.format("%Y-%m-%d %H:%M"), ep.role, &ep.content[..ep.content.len().min(120)]);
+                println!(
+                    "[{}] {}: {}",
+                    ep.created_at.format("%Y-%m-%d %H:%M"),
+                    ep.role,
+                    &ep.content[..ep.content.len().min(120)]
+                );
             }
         }
         MemoryCommands::Recent { session_id, limit } => {
             let results = memory.recent(session_id, limit).await?;
             for ep in results {
-                println!("[{}] {}: {}", ep.created_at.format("%Y-%m-%d %H:%M"), ep.role, &ep.content[..ep.content.len().min(120)]);
+                println!(
+                    "[{}] {}: {}",
+                    ep.created_at.format("%Y-%m-%d %H:%M"),
+                    ep.role,
+                    &ep.content[..ep.content.len().min(120)]
+                );
             }
         }
     }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use clap::Args;
-use harness_core::{config::Config, providers::ClaudeProvider, provider::Provider};
+use harness_core::{config::Config, provider::Provider, providers::ClaudeProvider};
 use harness_memory::MemoryDb;
 
 use crate::agent::Agent;
@@ -20,17 +20,25 @@ pub struct RunArgs {
 pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     let config = Config::load()?;
 
-    let backend = args.provider.as_deref().unwrap_or(&config.provider.backend).to_string();
+    let backend = args
+        .provider
+        .as_deref()
+        .unwrap_or(&config.provider.backend)
+        .to_string();
     let provider: Arc<dyn Provider> = match backend.as_str() {
         "echo" => {
             tracing::info!("using echo provider (no LLM calls)");
             Arc::new(harness_core::provider::EchoProvider)
         }
-        "claude" | _ => {
+        _ => {
             let api_key = config.resolved_api_key().ok_or_else(|| {
                 anyhow::anyhow!("ANTHROPIC_API_KEY not set — pass via env or config")
             })?;
-            Arc::new(ClaudeProvider::new(api_key, &config.provider.model, config.provider.max_tokens))
+            Arc::new(ClaudeProvider::new(
+                api_key,
+                &config.provider.model,
+                config.provider.max_tokens,
+            ))
         }
     };
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,7 +2,7 @@ mod agent;
 mod commands;
 
 use clap::{Parser, Subcommand};
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::{fmt, EnvFilter};
 
 /// paperclip-harness — provider-agnostic Rust agent harness.
 #[derive(Parser)]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -54,7 +54,10 @@ impl Default for Config {
                 api_key: None,
                 base_url: None,
             },
-            memory: MemoryConfig { db_path, max_context_episodes: 20 },
+            memory: MemoryConfig {
+                db_path,
+                max_context_episodes: 20,
+            },
             agent: AgentConfig {
                 name: "harness".to_string(),
                 system_prompt: None,
@@ -78,13 +81,14 @@ impl Config {
 
     /// Resolve API key: config file → environment variable.
     pub fn resolved_api_key(&self) -> Option<String> {
-        self.provider.api_key.clone().or_else(|| {
-            match self.provider.backend.as_str() {
+        self.provider
+            .api_key
+            .clone()
+            .or_else(|| match self.provider.backend.as_str() {
                 "claude" => std::env::var("ANTHROPIC_API_KEY").ok(),
                 "openai" => std::env::var("OPENAI_API_KEY").ok(),
                 _ => None,
-            }
-        })
+            })
     }
 }
 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -29,22 +29,40 @@ pub enum MessageContent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
-    Text { text: String },
-    ToolUse { id: String, name: String, input: serde_json::Value },
-    ToolResult { tool_use_id: String, content: String },
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
 }
 
 impl Message {
     pub fn system(text: impl Into<String>) -> Self {
-        Self { role: Role::System, content: MessageContent::Text(text.into()) }
+        Self {
+            role: Role::System,
+            content: MessageContent::Text(text.into()),
+        }
     }
 
     pub fn user(text: impl Into<String>) -> Self {
-        Self { role: Role::User, content: MessageContent::Text(text.into()) }
+        Self {
+            role: Role::User,
+            content: MessageContent::Text(text.into()),
+        }
     }
 
     pub fn assistant(text: impl Into<String>) -> Self {
-        Self { role: Role::Assistant, content: MessageContent::Text(text.into()) }
+        Self {
+            role: Role::Assistant,
+            content: MessageContent::Text(text.into()),
+        }
     }
 
     /// Extract plain text from any content variant.
@@ -52,7 +70,11 @@ impl Message {
         match &self.content {
             MessageContent::Text(s) => Some(s.as_str()),
             MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| {
-                if let ContentBlock::Text { text } = b { Some(text.as_str()) } else { None }
+                if let ContentBlock::Text { text } = b {
+                    Some(text.as_str())
+                } else {
+                    None
+                }
             }),
         }
     }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,7 +1,10 @@
+use crate::{
+    error::Result,
+    message::{Message, TurnResponse},
+};
 use async_trait::async_trait;
-use std::pin::Pin;
 use futures::Stream;
-use crate::{error::Result, message::{Message, TurnResponse}};
+use std::pin::Pin;
 
 /// A streaming token chunk from the provider.
 #[derive(Debug, Clone)]
@@ -29,7 +32,10 @@ pub trait Provider: Send + Sync + 'static {
         use futures::stream;
         let response = self.complete(messages).await?;
         let text = response.message.text().unwrap_or("").to_string();
-        let chunk = StreamChunk { delta: text, done: true };
+        let chunk = StreamChunk {
+            delta: text,
+            done: true,
+        };
         Ok(Box::pin(stream::once(async move { Ok(chunk) })))
     }
 
@@ -50,9 +56,16 @@ impl Provider for EchoProvider {
 
     async fn complete(&self, messages: &[Message]) -> Result<TurnResponse> {
         use crate::message::{MessageContent, Role, StopReason, Usage};
-        let last = messages.last().and_then(|m| m.text()).unwrap_or("(empty)").to_string();
+        let last = messages
+            .last()
+            .and_then(|m| m.text())
+            .unwrap_or("(empty)")
+            .to_string();
         Ok(TurnResponse {
-            message: Message { role: Role::Assistant, content: MessageContent::Text(format!("echo: {last}")) },
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(format!("echo: {last}")),
+            },
             stop_reason: StopReason::EndTurn,
             usage: Usage::default(),
             model: "echo".to_string(),

--- a/crates/core/src/providers/claude.rs
+++ b/crates/core/src/providers/claude.rs
@@ -65,7 +65,9 @@ struct ApiResponse {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ApiContent {
-    Text { text: String },
+    Text {
+        text: String,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -113,10 +115,14 @@ impl Provider for ClaudeProvider {
                     };
                     let content = match &msg.content {
                         MessageContent::Text(t) => serde_json::Value::String(t.clone()),
-                        MessageContent::Blocks(blocks) => serde_json::to_value(blocks)
-                            .map_err(HarnessError::Serialization)?,
+                        MessageContent::Blocks(blocks) => {
+                            serde_json::to_value(blocks).map_err(HarnessError::Serialization)?
+                        }
                     };
-                    api_messages.push(ApiMessage { role: role.to_string(), content });
+                    api_messages.push(ApiMessage {
+                        role: role.to_string(),
+                        content,
+                    });
                 }
             }
         }
@@ -148,7 +154,10 @@ impl Provider for ClaudeProvider {
                 .map(|e| e.error.message)
                 .unwrap_or(raw);
             warn!(status = %status, error = %msg, "Anthropic API error");
-            return Err(HarnessError::Api { status: status.as_u16(), body: msg });
+            return Err(HarnessError::Api {
+                status: status.as_u16(),
+                body: msg,
+            });
         }
 
         let api_resp: ApiResponse = resp
@@ -159,7 +168,13 @@ impl Provider for ClaudeProvider {
         let text = api_resp
             .content
             .iter()
-            .filter_map(|c| if let ApiContent::Text { text } = c { Some(text.as_str()) } else { None })
+            .filter_map(|c| {
+                if let ApiContent::Text { text } = c {
+                    Some(text.as_str())
+                } else {
+                    None
+                }
+            })
             .collect::<Vec<_>>()
             .join("");
 

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,7 +1,7 @@
+use crate::message::Message;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::message::Message;
 
 /// A single agent run session.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/memory/src/db.rs
+++ b/crates/memory/src/db.rs
@@ -1,8 +1,8 @@
+use crate::episode::{Episode, EpisodeKind};
 use anyhow::Result;
-use sqlx::{Row, SqlitePool, sqlite::SqlitePoolOptions};
+use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool};
 use std::path::Path;
 use uuid::Uuid;
-use crate::episode::{Episode, EpisodeKind};
 
 /// SQLite-backed memory store.
 pub struct MemoryDb {
@@ -135,7 +135,7 @@ impl MemoryDb {
         .fetch_all(&self.pool)
         .await?;
 
-        rows.iter().map(|row| parse_row(row)).collect()
+        rows.iter().map(parse_row).collect()
     }
 
     /// Full-text search across episode content.
@@ -152,7 +152,7 @@ impl MemoryDb {
         .fetch_all(&self.pool)
         .await?;
 
-        rows.iter().map(|row| parse_row(row)).collect()
+        rows.iter().map(parse_row).collect()
     }
 
     pub fn pool(&self) -> &SqlitePool {
@@ -179,7 +179,9 @@ fn parse_row(row: &sqlx::sqlite::SqliteRow) -> Result<Episode> {
         kind,
         role: row.try_get("role")?,
         content: row.try_get("content")?,
-        metadata: metadata_str.as_deref().and_then(|s| serde_json::from_str(s).ok()),
+        metadata: metadata_str
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok()),
         created_at: chrono::DateTime::parse_from_rfc3339(&created_at_str)
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now()),

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod builtin;
 pub mod registry;
 pub mod schema;
-pub mod builtin;
 
-pub use registry::{ToolRegistry, ToolHandler};
+pub use registry::{ToolHandler, ToolRegistry};
 pub use schema::ToolSchema;

--- a/crates/tools/src/registry.rs
+++ b/crates/tools/src/registry.rs
@@ -1,8 +1,8 @@
+use crate::schema::ToolSchema;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use serde_json::Value;
 use std::sync::Arc;
-use crate::schema::ToolSchema;
 
 /// Result of executing a tool.
 #[derive(Debug, Clone)]
@@ -13,11 +13,17 @@ pub struct ToolOutput {
 
 impl ToolOutput {
     pub fn ok(content: impl Into<String>) -> Self {
-        Self { content: content.into(), is_error: false }
+        Self {
+            content: content.into(),
+            is_error: false,
+        }
     }
 
     pub fn err(msg: impl Into<String>) -> Self {
-        Self { content: msg.into(), is_error: true }
+        Self {
+            content: msg.into(),
+            is_error: true,
+        }
     }
 }
 
@@ -95,7 +101,9 @@ mod tests {
     async fn registry_dispatches_tool() {
         let registry = ToolRegistry::new();
         registry.register(UpperCase);
-        let out = registry.call("uppercase", serde_json::json!({"text": "hello"})).await;
+        let out = registry
+            .call("uppercase", serde_json::json!({"text": "hello"}))
+            .await;
         assert_eq!(out.content, "HELLO");
         assert!(!out.is_error);
     }

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -51,7 +51,9 @@ mod tests {
     #[test]
     fn validates_required_fields() {
         let schema = ToolSchema::simple("bash", "Run a shell command", &["command"]);
-        assert!(schema.validate(&serde_json::json!({"command": "ls"})).is_ok());
+        assert!(schema
+            .validate(&serde_json::json!({"command": "ls"}))
+            .is_ok());
         assert!(schema.validate(&serde_json::json!({})).is_err());
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+[licenses]
+allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "ISC", "BSD-3-Clause", "Zlib", "Unicode-DFL"]
+deny = ["GPL-3.0", "AGPL-3.0"]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+
+[bans]
+multiple-versions = "warn"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Install git hooks for paperclip-harness development
+set -e
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/.githooks"
+GIT_HOOKS="$REPO_ROOT/.git/hooks"
+
+mkdir -p "$HOOKS_DIR"
+
+# Copy hooks from .githooks/ to .git/hooks/
+for hook in pre-commit pre-push commit-msg; do
+  if [ -f "$HOOKS_DIR/$hook" ]; then
+    cp "$HOOKS_DIR/$hook" "$GIT_HOOKS/$hook"
+    chmod +x "$GIT_HOOKS/$hook"
+    echo "✅ Installed $hook"
+  fi
+done
+
+echo "🎉 Git hooks installed. Run 'cargo fmt --all' and 'cargo clippy --workspace' before committing."


### PR DESCRIPTION
Adds developer quality tooling:
- `.githooks/`: pre-commit (fmt + clippy), pre-push (tests), commit-msg (conventional commits)
- `.cargo/config.toml`: cargo aliases for `check-all`, `test-all`, `fmt-check`
- `Cargo.toml`: workspace lint configuration
- `CONTRIBUTING.md`: hook setup instructions

Install hooks with: `bash scripts/setup-hooks.sh`