### PR TITLE
fix(tools): use tokio::fs::read_to_string in ReadFileTool

### DIFF
--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -92,7 +92,7 @@ impl ToolHandler for ReadFileTool {
         if p.components().any(|c| c == std::path::Component::ParentDir) {
             return ToolOutput::err("path traversal (..) is not allowed");
         }
-        match std::fs::read_to_string(&raw) {
+        match tokio::fs::read_to_string(&raw).await {
             Ok(contents) => ToolOutput::ok(contents),
             Err(e) => ToolOutput::err(format!("read_file failed for {raw}: {e}")),
         }


### PR DESCRIPTION
Replace std::fs::read_to_string with tokio::fs::read_to_string in ReadFileTool.

Closes ANGA-272