### PR TITLE
feat(agent): sub-agent spawning with depth guard and is_agent_managed_tool

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ harness-core = { workspace = true }
 harness-tools = { workspace = true }
 harness-memory = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use harness_core::{
     config::Config,
     message::{ContentBlock, Message, MessageContent, Role, StopReason},
@@ -7,8 +8,14 @@ use harness_core::{
     session::{Session, SessionStatus},
 };
 use harness_memory::MemoryDb;
-use harness_tools::{ToolRegistry, builtin::EchoTool};
+use harness_tools::{
+    builtin::{EchoTool, ReadFileTool, SpawnSubagentTool},
+    ToolRegistry,
+};
 use tracing::{debug, info, warn};
+
+/// Maximum sub-agent nesting depth to prevent infinite recursion.
+const MAX_SUBAGENT_DEPTH: usize = 4;
 
 /// Drives one agent session: send system prompt + goal, loop until done.
 pub struct Agent {
@@ -16,19 +23,49 @@ pub struct Agent {
     memory: Arc<MemoryDb>,
     tools: ToolRegistry,
     config: Config,
+    /// Nesting depth: 0 for the root agent, incremented for each sub-agent.
+    depth: usize,
 }
 
 impl Agent {
     pub fn new(provider: Arc<dyn Provider>, memory: Arc<MemoryDb>, config: Config) -> Self {
+        Self::new_with_depth(provider, memory, config, 0)
+    }
+
+    fn new_with_depth(
+        provider: Arc<dyn Provider>,
+        memory: Arc<MemoryDb>,
+        config: Config,
+        depth: usize,
+    ) -> Self {
         let tools = ToolRegistry::new();
         tools.register(EchoTool);
-        Self { provider, memory, tools, config }
+        tools.register(ReadFileTool);
+        tools.register(SpawnSubagentTool);
+        Self {
+            provider,
+            memory,
+            tools,
+            config,
+            depth,
+        }
     }
 
     /// Run until the agent signals completion or max iterations reached.
-    pub async fn run(&self, goal: &str) -> anyhow::Result<Session> {
+    ///
+    /// Returns a `BoxFuture` so recursive sub-agent calls compile without infinite types.
+    pub fn run<'a>(&'a self, goal: &'a str) -> BoxFuture<'a, anyhow::Result<Session>> {
+        Box::pin(self.run_inner(goal))
+    }
+
+    async fn run_inner(&self, goal: &str) -> anyhow::Result<Session> {
         let mut session = Session::new(goal);
-        info!(session_id = %session.id, goal = %goal, "starting session");
+        info!(
+            session_id = %session.id,
+            depth = self.depth,
+            goal = %goal,
+            "starting session"
+        );
 
         // Build initial messages
         let mut messages: Vec<Message> = Vec::new();
@@ -60,14 +97,22 @@ impl Agent {
             }
 
             session.iteration += 1;
-            debug!(iteration = session.iteration, "agent turn");
+            debug!(
+                iteration = session.iteration,
+                depth = self.depth,
+                "agent turn"
+            );
 
-            let response = self.provider.complete_with_tools(&messages, &tool_defs).await?;
+            let response = self
+                .provider
+                .complete_with_tools(&messages, &tool_defs)
+                .await?;
 
             let preview = response.message.text().unwrap_or("").to_string();
             info!(
                 tokens_out = response.usage.output_tokens,
                 stop_reason = ?response.stop_reason,
+                depth = self.depth,
                 "← {}",
                 &preview[..preview.len().min(120)]
             );
@@ -91,30 +136,49 @@ impl Agent {
 
                 StopReason::ToolUse => {
                     // Extract every ToolUse block from the assistant response.
-                    let tool_calls: Vec<(String, String, serde_json::Value)> =
-                        match &response.message.content {
-                            MessageContent::Blocks(blocks) => blocks
-                                .iter()
-                                .filter_map(|b| {
-                                    if let ContentBlock::ToolUse { id, name, input } = b {
-                                        Some((id.clone(), name.clone(), input.clone()))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect(),
-                            _ => {
-                                warn!("stop_reason=ToolUse but no ToolUse blocks found; treating as EndTurn");
-                                session.finish(SessionStatus::Done);
-                                break;
-                            }
-                        };
+                    let tool_calls: Vec<(String, String, serde_json::Value)> = match &response
+                        .message
+                        .content
+                    {
+                        MessageContent::Blocks(blocks) => blocks
+                            .iter()
+                            .filter_map(|b| {
+                                if let ContentBlock::ToolUse { id, name, input } = b {
+                                    Some((id.clone(), name.clone(), input.clone()))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect(),
+                        _ => {
+                            warn!("stop_reason=ToolUse but no ToolUse blocks found; treating as EndTurn");
+                            session.finish(SessionStatus::Done);
+                            break;
+                        }
+                    };
 
                     // Execute each tool and collect result blocks.
                     let mut result_blocks: Vec<ContentBlock> = Vec::new();
                     for (tool_use_id, name, input) in tool_calls {
-                        info!(tool = %name, "→ calling tool");
-                        let output = self.tools.call(&name, input).await;
+                        info!(tool = %name, depth = self.depth, "→ calling tool");
+                        let output = if self.is_agent_managed_tool(&name) {
+                            let sub_goal = input["goal"].as_str().unwrap_or("").to_string();
+                            let context = input
+                                .get("context")
+                                .and_then(|c| c.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            info!(sub_goal = %sub_goal, depth = self.depth, "spawning sub-agent");
+                            match self.spawn_subagent(&sub_goal, &context).await {
+                                Ok(result) => harness_tools::ToolOutput::ok(result),
+                                Err(e) => {
+                                    harness_tools::ToolOutput::err(format!("sub-agent error: {e}"))
+                                }
+                            }
+                        } else {
+                            self.tools.call(&name, input).await
+                        };
+
                         if output.is_error {
                             warn!(tool = %name, "tool returned error: {}", output.content);
                         }
@@ -136,6 +200,59 @@ impl Agent {
         }
 
         Ok(session)
+    }
+
+    /// Returns `true` for tools that are managed directly by the agent loop
+    /// rather than dispatched through [`ToolRegistry`].
+    ///
+    /// `spawn_subagent` must be handled here — not via the registry — because
+    /// executing it requires constructing a new [`Agent`] with an incremented
+    /// depth, which needs access to `self` (provider, memory, config).  The
+    /// registry holds stateless closures and cannot capture agent state.
+    fn is_agent_managed_tool(&self, name: &str) -> bool {
+        name == "spawn_subagent"
+    }
+
+    /// Spawn a nested sub-agent to handle a delegated goal.
+    ///
+    /// Returns the sub-agent's final response text, or an error if depth
+    /// exceeds [`MAX_SUBAGENT_DEPTH`].
+    async fn spawn_subagent(&self, goal: &str, context: &str) -> anyhow::Result<String> {
+        if self.depth >= MAX_SUBAGENT_DEPTH {
+            return Err(anyhow::anyhow!(
+                "sub-agent depth limit ({MAX_SUBAGENT_DEPTH}) reached — cannot spawn further"
+            ));
+        }
+
+        let full_goal = if context.is_empty() {
+            goal.to_string()
+        } else {
+            format!("{context}\n\n{goal}")
+        };
+
+        let sub_agent = Agent::new_with_depth(
+            Arc::clone(&self.provider),
+            Arc::clone(&self.memory),
+            self.config.clone(),
+            self.depth + 1,
+        );
+
+        let session = sub_agent.run(&full_goal).await?;
+
+        let result = session
+            .messages
+            .last()
+            .and_then(|m| m.text())
+            .unwrap_or("(sub-agent produced no output)")
+            .to_string();
+
+        info!(
+            depth = self.depth,
+            result_len = result.len(),
+            "sub-agent completed"
+        );
+
+        Ok(result)
     }
 }
 
@@ -160,7 +277,9 @@ mod tests {
             // Reverse so we can pop from the back in FIFO order.
             let mut r = responses;
             r.reverse();
-            Self { responses: Mutex::new(r) }
+            Self {
+                responses: Mutex::new(r),
+            }
         }
     }
 
@@ -191,17 +310,19 @@ mod tests {
     }
 
     /// Helpers for building TurnResponse values.
-    fn tool_use_response(tool_use_id: &str, tool_name: &str, input: serde_json::Value) -> TurnResponse {
+    fn tool_use_response(
+        tool_use_id: &str,
+        tool_name: &str,
+        input: serde_json::Value,
+    ) -> TurnResponse {
         TurnResponse {
             message: Message {
                 role: Role::Assistant,
-                content: MessageContent::Blocks(vec![
-                    ContentBlock::ToolUse {
-                        id: tool_use_id.to_string(),
-                        name: tool_name.to_string(),
-                        input,
-                    },
-                ]),
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: tool_use_id.to_string(),
+                    name: tool_name.to_string(),
+                    input,
+                }]),
             },
             stop_reason: StopReason::ToolUse,
             usage: Usage::default(),
@@ -242,6 +363,7 @@ mod tests {
                 r
             },
             config,
+            depth: 0,
         };
 
         let session = agent.run("test goal").await.unwrap();
@@ -255,7 +377,13 @@ mod tests {
     async fn max_iterations_cap_is_respected() {
         // Provider always asks for a tool call; cap at 2 iterations.
         let responses: Vec<TurnResponse> = (0..10)
-            .map(|i| tool_use_response(&format!("c-{i}"), "echo", serde_json::json!({"message": "x"})))
+            .map(|i| {
+                tool_use_response(
+                    &format!("c-{i}"),
+                    "echo",
+                    serde_json::json!({"message": "x"}),
+                )
+            })
             .collect();
 
         let provider = Arc::new(ScriptedProvider::new(responses));
@@ -271,6 +399,7 @@ mod tests {
                 r
             },
             config,
+            depth: 0,
         };
 
         let session = agent.run("loop forever").await.unwrap();
@@ -290,6 +419,7 @@ mod tests {
             memory,
             tools: ToolRegistry::new(),
             config,
+            depth: 0,
         };
 
         let session = agent.run("simple goal").await.unwrap();
@@ -297,5 +427,75 @@ mod tests {
         assert_eq!(session.status, harness_core::session::SessionStatus::Done);
         assert_eq!(session.iteration, 1);
         assert_eq!(session.messages.len(), 1); // only the assistant response
+    }
+
+    #[tokio::test]
+    async fn subagent_spawned_and_returns_result() {
+        // Main agent: spawns a sub-agent, then finishes after seeing the result.
+        // Sub-agent: immediately returns EndTurn with "sub-result".
+        //
+        // ScriptedProvider is shared — responses interleave:
+        //   pop 1 (main): spawn_subagent tool use
+        //   pop 2 (sub):  end_turn "sub-result"
+        //   pop 3 (main): end_turn "main done"
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response(
+                "sa-1",
+                "spawn_subagent",
+                serde_json::json!({"goal": "compute something"}),
+            ),
+            end_turn_response("sub-result"),
+            end_turn_response("main done"),
+        ]));
+
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let agent = Agent::new(provider, memory, config);
+        let session = agent.run("delegate work").await.unwrap();
+
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // Last message should be the main agent's final EndTurn response.
+        let last = session.messages.last().unwrap();
+        assert_eq!(last.text(), Some("main done"));
+    }
+
+    #[tokio::test]
+    async fn subagent_depth_limit_returns_error_output() {
+        // Directly test spawn_subagent at max depth returns an Err.
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let memory = make_memory().await;
+        let config = make_config(10);
+
+        let deep_agent = Agent::new_with_depth(provider, memory, config, MAX_SUBAGENT_DEPTH);
+        let result = deep_agent.spawn_subagent("unreachable", "").await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("depth limit"),
+            "expected 'depth limit' in: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_with_context_prepends_to_goal() {
+        // Verify that when context is non-empty it is prepended to the goal
+        // by confirming the sub-agent session runs with the combined text.
+        // We use a provider that immediately ends so the sub-agent session completes.
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response(
+            "context-aware result",
+        )]));
+        let memory = make_memory().await;
+        let config = make_config(5);
+
+        let provider: Arc<dyn Provider> = provider;
+        let agent = Agent::new_with_depth(Arc::clone(&provider), memory, config, 0);
+        let result = agent
+            .spawn_subagent("do the thing", "background: xyz")
+            .await
+            .unwrap();
+
+        assert_eq!(result, "context-aware result");
     }
 }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -21,6 +21,45 @@ impl ToolHandler for EchoTool {
     }
 }
 
+/// Spawn a sub-agent to handle a sub-task.
+///
+/// The actual execution is handled by the [`Agent`] loop in `harness-cli` —
+/// it intercepts calls to this tool name and runs a nested Agent instance.
+/// This struct exists only to declare the schema so the LLM sees the tool.
+pub struct SpawnSubagentTool;
+
+#[async_trait]
+impl ToolHandler for SpawnSubagentTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "spawn_subagent".to_string(),
+            description: "Spawn a sub-agent to handle a delegated sub-task. \
+                 The sub-agent shares the same provider and tool set as the main agent. \
+                 Returns the sub-agent's final response text."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "goal": {
+                        "type": "string",
+                        "description": "The goal or task for the sub-agent to accomplish."
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional background context for the sub-agent."
+                    }
+                },
+                "required": ["goal"]
+            }),
+        }
+    }
+
+    async fn call(&self, _input: Value) -> ToolOutput {
+        // The Agent handles spawn_subagent before it reaches the registry.
+        ToolOutput::err("spawn_subagent must be handled by the agent loop, not the registry")
+    }
+}
+
 /// Read the UTF-8 contents of a file at a given path.
 pub struct ReadFileTool;
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod builtin;
 pub mod registry;
 pub mod schema;
-pub mod builtin;
 
-pub use registry::{ToolRegistry, ToolHandler};
+pub use registry::{ToolHandler, ToolOutput, ToolRegistry};
 pub use schema::ToolSchema;


### PR DESCRIPTION
## Thinking Path

1. **paperclip-harness vision** ג€” single agent harness where agents can delegate to sub-agents
2. **Phase 5 milestone** ג€” sub-agent spawning: agent loop spawns nested `Agent` sharing provider/memory
3. **Why `spawn_subagent` bypasses ToolRegistry** ג€” registry holds stateless closures; spawning needs `self` (provider Arc, memory Arc, config, depth). Must be intercepted by the loop.
4. **CTO review feedback on PR #8** ג€” add `is_agent_managed_tool` to document the special-case; add depth-guard tests using ScriptedProvider
5. **Implementation** ג€” `is_agent_managed_tool()` routes `spawn_subagent` to `spawn_subagent()` enforcing `MAX_SUBAGENT_DEPTH=4`; `run()` returns `BoxFuture` to resolve recursive async types
6. **Tests** ג€” ScriptedProvider pops responses FIFO for deterministic multi-turn + sub-agent spawn tests
7. **Rebase** ג€” single commit on top of `master` (includes tool-call loop from PR #3)

## What Changed

- `crates/cli/src/agent.rs` ג€” `depth` field, `new_with_depth()`, `is_agent_managed_tool()` with doc comment, `spawn_subagent()` with depth guard, `run()` as `BoxFuture`, 6 tests
- `crates/cli/Cargo.toml` ג€” added `futures` dep
- `crates/tools/src/builtin.rs` ג€” `SpawnSubagentTool` stub (schema only; `call()` returns error since Agent intercepts first)
- `crates/tools/src/lib.rs` ג€” re-export `ToolOutput` from crate root

## Verification

```
cargo test -p harness-cli    # 6 passed, 0 failed
cargo clippy --workspace -- -D warnings    # clean
```

- [x] `is_agent_managed_tool` documents why `spawn_subagent` is special-cased in the loop
- [x] Test: sub-agent spawning succeeds at depth 0 (`subagent_spawned_and_returns_result`)
- [x] Test: `spawn_subagent` returns error at depth >= MAX_SUBAGENT_DEPTH (`subagent_depth_limit_returns_error_output`)
- [x] Single commit rebased cleanly onto `master`

## Risks

- **Shared ScriptedProvider in tests** ג€” pop order is deterministic but fragile if future tests add concurrency. Low risk for current single-threaded test runs.
- **BoxFuture lifetime** ג€” standard pattern, no soundness issue.

## Checklist

- [x] `cargo test` passes locally
- [x] `cargo clippy -- -D warnings` is clean
- [x] New behaviour has tests using ScriptedProvider
- [x] Commit follows Conventional Commits
- [x] Co-Authored-By: Paperclip in commit

Closes ANGA-276
