### PR TITLE
feat(assets): add Anvil logo and icon SVG

### DIFF
--- a/assets/anvil-icon.svg
+++ b/assets/anvil-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Anvil icon">
+  <!-- Anvil silhouette: horn (left), face (top), body (base) -->
+  <path
+    d="M3,19 L16,8 L58,8 L58,30 L60,30 L60,56 L4,56 L4,30 L16,30 Z"
+    fill="#2D3748"
+  />
+  <!-- Face highlight (top edge of working surface) -->
+  <rect x="16" y="8" width="42" height="3" rx="1" fill="#718096"/>
+  <!-- Body step highlight -->
+  <rect x="4" y="30" width="56" height="3" rx="1" fill="#718096" opacity="0.4"/>
+</svg>

--- a/assets/anvil-logo.svg
+++ b/assets/anvil-logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 100" role="img" aria-label="Anvil">
+  <!-- Anvil silhouette: horn (left), face (top), body (base) -->
+  <path
+    d="M8,50 L46,18 L222,18 L222,60 L232,60 L232,90 L8,90 L8,60 L46,60 Z"
+    fill="#2D3748"
+  />
+  <!-- Face highlight (top edge of working surface) -->
+  <rect x="46" y="18" width="176" height="6" rx="1" fill="#718096"/>
+  <!-- Body step highlight -->
+  <rect x="8" y="60" width="224" height="4" rx="1" fill="#718096" opacity="0.4"/>
+</svg>


### PR DESCRIPTION
## Thinking Path
1. Project renamed to **Anvil** (ANGA-302) - needs a logo
2. Logo consumed as README badge and agent dashboard icon
3. SVG: scalable, GitHub renders natively, no raster artifacts
4. Flat geometric style: no gradients/shadows, two-color palette from spec
5. Two files: 240x100 logo for README, 64x64 icon for dashboard
6. Single closed polygon path for silhouette + highlight rects

## What Changed
- `assets/anvil-logo.svg` - 240x100 flat anvil silhouette; horn left, face top, body base; #2D3748 + #718096
- `assets/anvil-icon.svg` - 64x64 square variant; same design scaled to square viewport

## Verification
- Open SVGs in browser or GitHub PR file preview to confirm rendering
- No external references, no gradients, no filters
- Well-formed XML with xmlns, viewBox, role, aria-label

## Risks
Low risk. New files only, no existing code touched.

## Checklist
- [x] Single-issue scope (ANGA-306 only)
- [x] No unrelated commits
- [x] Branched from `dev`, targeting `dev`
- [x] Co-authored commit with Paperclip

Closes ANGA-306