### PR TITLE
feat(assets): SVG creation skill + proper Anvil logo/icon (ANGA-306)

### DIFF
--- a/.claude/skills/svg-create/SKILL.md
+++ b/.claude/skills/svg-create/SKILL.md
@@ -1,0 +1,74 @@
+# SVG Creation Skill
+
+**Trigger:** "create SVG", "design SVG", "make a logo", "generate icon", "SVG logo", "vector graphic", "draw SVG"
+
+You are an expert SVG designer. When asked to create an SVG graphic, follow these principles.
+
+## Design Process
+
+1. **Identify the key landmark points** of the shape before writing any paths. Sketch on paper or in comments.
+2. **Use bezier curves** (`C`/`Q` commands) for organic, natural shapes. Use straight lines (`L`, `H`, `V`) only for truly rigid geometric edges.
+3. **Close all shape paths** with `Z`.
+4. **Test legibility at target size** — if creating an icon, verify it reads at the minimum display size.
+
+## SVG Template
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 W H" role="img" aria-label="Description">
+  <defs>
+    <!-- gradients, masks, clipPaths go here -->
+  </defs>
+
+  <!-- Group related elements -->
+  <g id="body">
+    <!-- main shape -->
+  </g>
+
+  <!-- Highlights / overlays last so they render on top -->
+  <g id="highlights" opacity="0.6">
+    <!-- thin rects or paths for edge highlights -->
+  </g>
+</svg>
+```
+
+## Path Command Reference
+
+| Command | Meaning | Example |
+|---------|---------|---------|
+| `M x,y` | Move to (start new subpath) | `M 10,50` |
+| `L x,y` | Line to | `L 80,50` |
+| `H x` | Horizontal line to | `H 100` |
+| `V y` | Vertical line to | `V 80` |
+| `C cx1,cy1 cx2,cy2 x,y` | Cubic bezier curve | `C 20,30 60,30 80,50` |
+| `Q cx,cy x,y` | Quadratic bezier curve | `Q 50,20 80,50` |
+| `A rx,ry rot laf sf x,y` | Arc | `A 10,10 0 0 1 80,50` |
+| `Z` | Close path | `Z` |
+
+## Silhouette Tips
+
+For complex silhouettes (animals, tools, objects):
+- Split into **structural layers**: base/body → mid-detail → highlights → overlay cutouts
+- Use `fill="currentColor"` when the graphic must adapt to dark/light themes
+- Use `fill="white"` for cutouts (holes) when on a solid background, or `fill-rule="evenodd"` with a compound path for theme-agnostic cutouts
+
+## Color Palettes
+
+**Dark metal (machinery, tools):**
+- Body: `#2D3748`
+- Face/surface: `#4A5568`
+- Edge highlights: `#718096`
+
+**Monochrome / adaptive:**
+- Use `fill="currentColor"` — inherits CSS color
+- Cutouts: compound path with `fill-rule="evenodd"` so holes remain transparent
+
+## Verification Checklist
+
+Before finalizing any SVG:
+- [ ] `viewBox` dimensions match the design intent
+- [ ] All fill paths are closed with `Z`
+- [ ] No external `href` references (self-contained SVG)
+- [ ] No `<image>` tags unless using data URIs
+- [ ] Icon variant: legible at 32×32 (squint test — can you tell what it is?)
+- [ ] Logo variant: wordmark and icon optically balanced
+- [ ] Renders correctly in both light and dark contexts (or colors are intentionally fixed)

--- a/assets/anvil-icon.svg
+++ b/assets/anvil-icon.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Anvil icon">
+  <!--
+    Anvil icon — 64×64, legible at 32×32.
+    Palette: #2D3748 body, #4A5568 face, #718096 highlights.
+    Anatomy: two feet → waist trapezoid → table body → top face → horn.
+    Hardy hole rendered as a semi-transparent overlay (theme-safe).
+    Scale factor: 0.64 of the 100×100 base grid, centered in 64×64 canvas.
+  -->
+  <g transform="translate(0, 2) scale(0.64)">
+
+    <!-- Feet -->
+    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+
+    <!-- Waist -->
+    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+
+    <!-- Table body -->
+    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+
+    <!-- Top face -->
+    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
+
+    <!-- Hardy hole -->
+    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
+
+    <!-- Horn -->
+    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
+
+    <!-- Horn edge highlight -->
+    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1.2" fill="none" opacity="0.6"/>
+
+    <!-- Table right-edge highlight -->
+    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none"
+          stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+
+  </g>
+</svg>

--- a/assets/anvil-logo.svg
+++ b/assets/anvil-logo.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 100" role="img" aria-label="Anvil">
+  <!--
+    Anvil — provider-agnostic Rust AI agent runtime
+    Logo lockup: icon (left) + wordmark (right)
+    Palette: #2D3748 body, #4A5568 face, #718096 highlights
+
+    Icon anatomy (scaled to fit left 80px, centered vertically in 100px):
+      - Top face: flat work surface
+      - Horn: left-pointing taper off the table
+      - Table body: hexagonal platform
+      - Waist: trapezoid taper
+      - Feet: two rectangular feet
+      - Hardy hole: small cutout in the table
+  -->
+
+  <!-- === ICON (scale 0.72 of 100x100 base, translate to center in 100x100 left zone) === -->
+  <g transform="translate(6, 4) scale(0.72)">
+
+    <!-- Feet -->
+    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+
+    <!-- Waist -->
+    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+
+    <!-- Table body -->
+    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+
+    <!-- Table top face highlight -->
+    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
+
+    <!-- Hardy hole cutout -->
+    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
+
+    <!-- Horn -->
+    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
+
+    <!-- Horn tip edge highlight -->
+    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1" fill="none" opacity="0.6"/>
+
+    <!-- Table edge highlight (right side) -->
+    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+
+  </g>
+
+  <!-- Divider -->
+  <line x1="82" y1="18" x2="82" y2="82" stroke="#2D3748" stroke-width="1" opacity="0.15"/>
+
+  <!--
+    === WORDMARK: "anvil" ===
+    Stroke-based geometric sans letterforms.
+    Cap height: 30px. Baseline: y=62. Start: x=93.
+    Stroke: width=4.5, round caps+joins.
+
+    a — circle bowl + right descender stem
+    n — left stem + arch + right stem
+    v — chevron
+    i — stem + dot
+    l — tall stem
+  -->
+  <g fill="none" stroke="#2D3748" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
+
+    <!-- a: bowl (center 104,52, r=10) open right side + descending stem -->
+    <path d="M114 52 A10 10 0 1 0 114 54"/>
+    <line x1="114" y1="42" x2="114" y2="63"/>
+
+    <!-- n: left stem + arch + right stem -->
+    <line x1="127" y1="42" x2="127" y2="63"/>
+    <path d="M127 47 C127 39 135 39 135 39 C143 39 143 47 143 47 L143 63"/>
+
+    <!-- v: two converging legs -->
+    <polyline points="150,41 158,63 166,41"/>
+
+    <!-- i: stem + dot -->
+    <line x1="174" y1="49" x2="174" y2="63"/>
+    <circle cx="174" cy="40" r="2.8" fill="#2D3748" stroke="none"/>
+
+    <!-- l: tall stem -->
+    <line x1="184" y1="30" x2="184" y2="63"/>
+
+  </g>
+
+</svg>


### PR DESCRIPTION
## Thinking Path

1. ANGA-302 — Branding rename to anvil
2. ANGA-306 — Board rejected first logo attempt — requested SVG creation skill + proper logo
3. Checked origin/dev for existing assets — used high-quality anvil.svg anatomy as design basis
4. Issue spec requires anvil-logo.svg (240x100) and anvil-icon.svg (64x64) with dark metal palette
5. Created SVG skill first, applied its checklist to verify output
6. Layered approach: body fill → face highlight → edge highlights → hardy hole overlay
7. Wordmark uses stroke-based geometric letterforms — no font dependency

## What Changed

- `.claude/skills/svg-create/SKILL.md` — reusable SVG skill with path reference, design process, checklist
- `assets/anvil-logo.svg` (240x100) — icon + stroke wordmark, dark metal palette, proper anvil anatomy
- `assets/anvil-icon.svg` (64x64) — icon-only variant, legible at 32x32

## Verification

- [x] anvil-logo.svg viewBox 0 0 240 100
- [x] anvil-icon.svg viewBox 0 0 64 64
- [x] Both self-contained (no external refs)
- [x] Anvil anatomy: feet, waist, table, face, horn, hardy hole
- [x] SVG skill at .claude/skills/svg-create/SKILL.md

## Risks

Low risk — additive only. No Rust source, CI, or Cargo.toml touched.

## Checklist

- [x] PR targets dev
- [x] 1 commit, 3 files, all in-scope
- [x] Co-Authored-By: Paperclip present

Closes ANGA-306