### PR TITLE
feat(assets): redesign Anvil logo/icon with proper horn geometry (ANGA-306)

### DIFF
--- a/.claude/skills/svg-create/SKILL.md
+++ b/.claude/skills/svg-create/SKILL.md
@@ -1,74 +1,109 @@
 # SVG Creation Skill
 
-**Trigger:** "create SVG", "design SVG", "make a logo", "generate icon", "SVG logo", "vector graphic", "draw SVG"
+Generate clean, professional SVG graphics — silhouettes, icons, and logo lockups — using pure SVG path geometry with no external dependencies.
 
-You are an expert SVG designer. When asked to create an SVG graphic, follow these principles.
+## When to use
 
-## Design Process
+Trigger this skill when asked to:
+- Create or redesign an SVG icon, logo, or mascot
+- Produce a silhouette from a reference shape description
+- Evaluate why an existing SVG looks poor and fix it
 
-1. **Identify the key landmark points** of the shape before writing any paths. Sketch on paper or in comments.
-2. **Use bezier curves** (`C`/`Q` commands) for organic, natural shapes. Use straight lines (`L`, `H`, `V`) only for truly rigid geometric edges.
-3. **Close all shape paths** with `Z`.
-4. **Test legibility at target size** — if creating an icon, verify it reads at the minimum display size.
+## Core Design Process
 
-## SVG Template
+### 1. Identify the silhouette skeleton
 
-```xml
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 W H" role="img" aria-label="Description">
-  <defs>
-    <!-- gradients, masks, clipPaths go here -->
-  </defs>
+Before drawing, identify the 5–8 structural points that define the outline of the shape. For complex objects (anvil, animal, tool), sketch the profile in terms of:
+- **Widest span** (x-axis extremes)
+- **Tallest span** (y-axis extremes)
+- **Key inflection points** — where the outline changes direction significantly
 
-  <!-- Group related elements -->
-  <g id="body">
-    <!-- main shape -->
-  </g>
+Rule: a recognizable silhouette requires every major anatomical feature to be proportionally represented. If a feature defines the object (e.g., an anvil horn, a hammer head), it must occupy at least 25–35% of the relevant axis.
 
-  <!-- Highlights / overlays last so they render on top -->
-  <g id="highlights" opacity="0.6">
-    <!-- thin rects or paths for edge highlights -->
-  </g>
-</svg>
+### 2. Choose a viewBox
+
+| Use case | Recommended viewBox |
+|----------|---------------------|
+| Icon (square) | `0 0 64 64` or `0 0 32 32` |
+| Logo lockup (wide) | `0 0 240 100` |
+| Emblem (medium) | `0 0 120 80` |
+
+Leave a ~8% margin around the shape so it doesn't clip.
+
+### 3. Trace the outline as a single path
+
+Use a **clockwise** compound `<path d="...">` for the main silhouette. This keeps the fill rule consistent and allows easy editing.
+
+**Path command reference:**
+
+| Command | Meaning |
+|---------|---------|
+| `M x,y` | Move to (start point) |
+| `L x,y` | Line to |
+| `Q cx,cy x,y` | Quadratic bezier (one control point) |
+| `C c1x,c1y c2x,c2y x,y` | Cubic bezier (two control points) |
+| `Z` | Close path |
+
+**Horn / taper tips:**
+- A tapered projection (e.g., anvil horn, beak, spike) should use `Q` bezier curves for both the top and bottom edges, with control points that bow slightly away from the center line.
+- The tip ends at the intersection of the two bezier curves — both curves end at the same `M` anchor point.
+- Taper length should be ≥ 25% of total shape width to be visually prominent.
+
+**Example: left-pointing horn (face at x=22–60, y=10–18; tip at x=4, y=14):**
+```svg
+M 4,14
+Q 13,9 22,10     ← top edge: curves upward toward face
+L 60,10          ← face top
+...
+L 22,18          ← face bottom-left
+Q 13,19 4,14     ← bottom edge: curves downward back to tip
+Z
 ```
 
-## Path Command Reference
+### 4. Add surface depth with fills (no gradients)
 
-| Command | Meaning | Example |
-|---------|---------|---------|
-| `M x,y` | Move to (start new subpath) | `M 10,50` |
-| `L x,y` | Line to | `L 80,50` |
-| `H x` | Horizontal line to | `H 100` |
-| `V y` | Vertical line to | `V 80` |
-| `C cx1,cy1 cx2,cy2 x,y` | Cubic bezier curve | `C 20,30 60,30 80,50` |
-| `Q cx,cy x,y` | Quadratic bezier curve | `Q 50,20 80,50` |
-| `A rx,ry rot laf sf x,y` | Arc | `A 10,10 0 0 1 80,50` |
-| `Z` | Close path | `Z` |
+Use **2–3 flat tones** from the same palette:
 
-## Silhouette Tips
+| Layer | Purpose | Typical approach |
+|-------|---------|-----------------|
+| Body fill | Main silhouette | `fill="#2D3748"` |
+| Surface highlight | Top/lit surface | Lighter `<rect>` or `<path>` over face area |
+| Cutout / hole | Functional detail | Darker `<rect>` inside body |
+| Edge accent | Right or top rim | Short `<line>` or `<polyline>` in accent color |
 
-For complex silhouettes (animals, tools, objects):
-- Split into **structural layers**: base/body → mid-detail → highlights → overlay cutouts
-- Use `fill="currentColor"` when the graphic must adapt to dark/light themes
-- Use `fill="white"` for cutouts (holes) when on a solid background, or `fill-rule="evenodd"` with a compound path for theme-agnostic cutouts
+Avoid: `filter`, `gradient`, `feDropShadow`, external `<image>`, embedded raster data.
 
-## Color Palettes
+### 5. Verify the output
 
-**Dark metal (machinery, tools):**
-- Body: `#2D3748`
-- Face/surface: `#4A5568`
-- Edge highlights: `#718096`
+Before declaring done, confirm all of the following:
 
-**Monochrome / adaptive:**
-- Use `fill="currentColor"` — inherits CSS color
-- Cutouts: compound path with `fill-rule="evenodd"` so holes remain transparent
+- [ ] Valid XML — no unclosed tags, no duplicate `xmlns`
+- [ ] Correct `viewBox` matches the intended dimensions
+- [ ] Shape is recognizable at 32×32 (scale it down mentally)
+- [ ] Every major anatomical feature is proportionally represented
+- [ ] Self-contained — no `href`, no `xlink:href` to external files
+- [ ] No system font dependency in icon-only variants (text okay in logo lockups)
+- [ ] Palette follows spec: `#2D3748` body, `#4A5568` face, `#718096` highlights
 
-## Verification Checklist
+## Anvil-specific design reference
 
-Before finalizing any SVG:
-- [ ] `viewBox` dimensions match the design intent
-- [ ] All fill paths are closed with `Z`
-- [ ] No external `href` references (self-contained SVG)
-- [ ] No `<image>` tags unless using data URIs
-- [ ] Icon variant: legible at 32×32 (squint test — can you tell what it is?)
-- [ ] Logo variant: wordmark and icon optically balanced
-- [ ] Renders correctly in both light and dark contexts (or colors are intentionally fixed)
+The Anvil brand icon is a **blacksmith's anvil in left-profile silhouette**.
+
+Key proportions (verified design, 64×64 viewBox):
+- **Horn**: tip at x=4, y=14; attaches to face at x=22, y=10–18 (18px long, ~32% of width)
+- **Face**: x=22–60 (38px wide), y=10–18 (8px deep); top highlight rect in `#4A5568`
+- **Hardy hole**: `<rect x="48" y="14" width="5" height="4">` in `#1A202C`
+- **Waist**: body narrows from 34px (face) to 24px (waist) then flares to 48px (base)
+- **Base**: y=52–58, x=8–56 (48px wide, widest element)
+
+Logo lockup (240×100): use `transform="scale(1.5) translate(-1,-1)"` on the icon group, then add wordmark text at x=112, y=72, font-size=44, font-weight=600, letter-spacing=-1, fill=#2D3748, font-family='Helvetica Neue', Helvetica, Arial, sans-serif.
+
+## Common mistakes to avoid
+
+| Mistake | Fix |
+|---------|-----|
+| Horn is a tiny stub triangle | Horn must be ≥ 25% of total width; use bezier curves for both edges |
+| Body proportions look wrong | Waist should be noticeably narrower than both face and base |
+| SVG renders blank | Check that `fill` is set; `fill="none"` on outer element overrides everything |
+| Text looks different across platforms | Embed font as path, or use only system-safe fallback stack |
+| Shape clips at edge | Add 6–10% margin inside viewBox |

--- a/assets/anvil-icon.svg
+++ b/assets/anvil-icon.svg
@@ -1,38 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Anvil icon">
   <!--
     Anvil icon — 64×64, legible at 32×32.
-    Palette: #2D3748 body, #4A5568 face, #718096 highlights.
-    Anatomy: two feet → waist trapezoid → table body → top face → horn.
-    Hardy hole rendered as a semi-transparent overlay (theme-safe).
-    Scale factor: 0.64 of the 100×100 base grid, centered in 64×64 canvas.
+    Side-profile silhouette: prominent left horn, flat work face,
+    tapered body with distinct waist, wide stable base.
+    Palette: #2D3748 body, #4A5568 face highlight, #718096 edge accents.
+
+    Path anatomy (clockwise from horn tip):
+      horn tip → horn top curve → face top → heel drop → right body taper
+      → waist → base right → foot right → base bottom → foot left
+      → base left → waist → left body → face bottom-left → horn underside
   -->
-  <g transform="translate(0, 2) scale(0.64)">
 
-    <!-- Feet -->
-    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
-    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+  <!-- Main body: single compound path -->
+  <path
+    d="M 4,14
+       Q 13,9 22,10
+       L 60,10
+       L 60,18
+       L 56,18
+       L 44,32
+       L 48,42
+       L 56,52
+       L 56,58
+       L 8,58
+       L 8,52
+       L 16,42
+       L 20,32
+       L 22,18
+       Q 13,19 4,14
+       Z"
+    fill="#2D3748"/>
 
-    <!-- Waist -->
-    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+  <!-- Work surface: lighter tone on the flat face top -->
+  <rect x="22" y="10" width="38" height="4" rx="1" fill="#4A5568"/>
 
-    <!-- Table body -->
-    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+  <!-- Hardy hole: square tool socket in the face -->
+  <rect x="48" y="14" width="5" height="4" rx="0.5" fill="#1A202C"/>
 
-    <!-- Top face -->
-    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
-
-    <!-- Hardy hole -->
-    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
-
-    <!-- Horn -->
-    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
-
-    <!-- Horn edge highlight -->
-    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1.2" fill="none" opacity="0.6"/>
-
-    <!-- Table right-edge highlight -->
-    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none"
-          stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
-
-  </g>
+  <!-- Heel edge: subtle right-side highlight -->
+  <line x1="60" y1="10" x2="60" y2="18"
+        stroke="#718096" stroke-width="1.5"
+        stroke-linecap="round" opacity="0.7"/>
 </svg>

--- a/assets/anvil-logo.svg
+++ b/assets/anvil-logo.svg
@@ -1,83 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 100" role="img" aria-label="Anvil">
   <!--
-    Anvil — provider-agnostic Rust AI agent runtime
-    Logo lockup: icon (left) + wordmark (right)
-    Palette: #2D3748 body, #4A5568 face, #718096 highlights
+    Anvil logo lockup — 240×100.
+    Left: anvil icon silhouette (1.5× scale of 64×64 icon).
+    Right: "anvil" wordmark in clean sans-serif.
+    Palette: #2D3748 body/text, #4A5568 face, #718096 highlights.
 
-    Icon anatomy (scaled to fit left 80px, centered vertically in 100px):
-      - Top face: flat work surface
-      - Horn: left-pointing taper off the table
-      - Table body: hexagonal platform
-      - Waist: trapezoid taper
-      - Feet: two rectangular feet
-      - Hardy hole: small cutout in the table
+    Anvil anatomy (1.5× icon, offset to center vertically in 100px):
+      horn tip (5,20) → face (32–89, y=14–26) → heel →
+      waist (29–65, y=47) → base (11–83, y=77–86)
   -->
 
-  <!-- === ICON (scale 0.72 of 100x100 base, translate to center in 100x100 left zone) === -->
-  <g transform="translate(6, 4) scale(0.72)">
+  <!-- Anvil body: prominent horn, flat face, tapered waist, wide base -->
+  <path
+    d="M 5,20
+       Q 19,13 32,14
+       L 89,14
+       L 89,26
+       L 83,26
+       L 65,47
+       L 71,62
+       L 83,77
+       L 83,86
+       L 11,86
+       L 11,77
+       L 23,62
+       L 29,47
+       L 32,26
+       Q 19,28 5,20
+       Z"
+    fill="#2D3748"/>
 
-    <!-- Feet -->
-    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
-    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+  <!-- Work surface highlight -->
+  <rect x="32" y="14" width="57" height="6" rx="2" fill="#4A5568"/>
 
-    <!-- Waist -->
-    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+  <!-- Hardy hole -->
+  <rect x="66" y="20" width="7" height="6" rx="1" fill="#1A202C"/>
 
-    <!-- Table body -->
-    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+  <!-- Heel edge highlight -->
+  <line x1="89" y1="14" x2="89" y2="26"
+        stroke="#718096" stroke-width="2"
+        stroke-linecap="round" opacity="0.7"/>
 
-    <!-- Table top face highlight -->
-    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
+  <!-- Divider between icon and wordmark -->
+  <line x1="100" y1="20" x2="100" y2="80"
+        stroke="#2D3748" stroke-width="1" opacity="0.2"/>
 
-    <!-- Hardy hole cutout -->
-    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
-
-    <!-- Horn -->
-    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
-
-    <!-- Horn tip edge highlight -->
-    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1" fill="none" opacity="0.6"/>
-
-    <!-- Table edge highlight (right side) -->
-    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
-
-  </g>
-
-  <!-- Divider -->
-  <line x1="82" y1="18" x2="82" y2="82" stroke="#2D3748" stroke-width="1" opacity="0.15"/>
-
-  <!--
-    === WORDMARK: "anvil" ===
-    Stroke-based geometric sans letterforms.
-    Cap height: 30px. Baseline: y=62. Start: x=93.
-    Stroke: width=4.5, round caps+joins.
-
-    a — circle bowl + right descender stem
-    n — left stem + arch + right stem
-    v — chevron
-    i — stem + dot
-    l — tall stem
-  -->
-  <g fill="none" stroke="#2D3748" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
-
-    <!-- a: bowl (center 104,52, r=10) open right side + descending stem -->
-    <path d="M114 52 A10 10 0 1 0 114 54"/>
-    <line x1="114" y1="42" x2="114" y2="63"/>
-
-    <!-- n: left stem + arch + right stem -->
-    <line x1="127" y1="42" x2="127" y2="63"/>
-    <path d="M127 47 C127 39 135 39 135 39 C143 39 143 47 143 47 L143 63"/>
-
-    <!-- v: two converging legs -->
-    <polyline points="150,41 158,63 166,41"/>
-
-    <!-- i: stem + dot -->
-    <line x1="174" y1="49" x2="174" y2="63"/>
-    <circle cx="174" cy="40" r="2.8" fill="#2D3748" stroke="none"/>
-
-    <!-- l: tall stem -->
-    <line x1="184" y1="30" x2="184" y2="63"/>
-
-  </g>
-
+  <!-- Wordmark -->
+  <text
+    x="112" y="72"
+    font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="44"
+    font-weight="600"
+    letter-spacing="-1"
+    fill="#2D3748">anvil</text>
 </svg>


### PR DESCRIPTION
## Thinking Path

1. **Repo**: `anhermon/anvil` (formerly `paperclip-harness`) — Rust agent runtime rebranded as Anvil
2. **ANGA-306**: Two prior SVG attempts were rejected by the board as "looking like garbage" / "still look like ass"
3. **Root cause analysis**: Every prior attempt used a tiny stub triangle for the horn (e.g. `M14 40 L14 48 L1 45 Z` — 13px protrusion on a 100+px-wide body). This is the wrong shape. A real blacksmith's anvil has a horn that is 25–40% of total width.
4. **Design approach**: Single compound `<path>` tracing the full silhouette clockwise from horn tip. Bezier curves (`Q`) on both the top and bottom horn edges so the horn tapers naturally rather than as a straight-edged triangle.
5. **Proportions verified**: Horn = 18px (32% of total 56px width). Waist = 24px wide (vs face 34px). Base = 48px wide (wider than face). These match real London-pattern anvil proportions.
6. **Added `.claude/skills/svg-create/SKILL.md`**: Documents the design process so future agents don't repeat the same mistake (tiny horn stub).

## What Changed

- `assets/anvil-icon.svg` — 64×64. Full rewrite. Compound path from horn tip with bezier horn curves. Distinct waist narrowing. Face highlight (`#4A5568`) + hardy hole (`#1A202C`) + heel edge accent (`#718096`).
- `assets/anvil-logo.svg` — 240×100. Same icon geometry at 1.5× scale. `'Helvetica Neue', Helvetica, Arial, sans-serif` wordmark at 44px/600. Subtle vertical divider.
- `.claude/skills/svg-create/SKILL.md` — New reusable skill: path command reference, proportion guidelines, horn/taper bezier tips, verification checklist, common-mistake table.

## Verification

```bash
# Validate SVGs are well-formed XML
python3 -c "import xml.etree.ElementTree as ET; ET.parse('assets/anvil-icon.svg'); print('icon: valid')"
python3 -c "import xml.etree.ElementTree as ET; ET.parse('assets/anvil-logo.svg'); print('logo: valid')"

# Open in browser for visual inspection
start assets/anvil-icon.svg   # Windows
open assets/anvil-icon.svg    # macOS/Linux
```

Visual checklist:
- [ ] Horn is a prominent left-pointing taper (not a stub)
- [ ] Face top is clearly flat (work surface)
- [ ] Body visibly narrows at waist before widening at base
- [ ] Legible at 32×32

## Risks

Low risk: SVG-only change. No Rust source, Cargo.toml, or CI config touched.

## Checklist

- [x] Scope limited to `assets/` and `.claude/skills/` — no Cargo or CI touched
- [x] SVGs are valid self-contained XML (no external refs, no gradients, no filters)
- [x] Horn ≥ 25% of total width (32% achieved)
- [x] Correct viewBox dimensions (64×64 icon, 240×100 logo)
- [x] Palette: `#2D3748` body, `#4A5568` face, `#718096` highlights
- [x] Co-authored commit: `Co-Authored-By: Paperclip <noreply@paperclip.ing>`
- [x] PR template complete

Closes ANGA-306