### PR TITLE
feat(paperclip): harness-paperclip crate + anvil paperclip CLI (Phase 7a, ANGA-70)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ harness-core = { path = "crates/core" }
 harness-tools = { path = "crates/tools" }
 harness-memory = { path = "crates/memory" }
 harness-github = { path = "crates/github" }
+harness-paperclip = { path = "crates/paperclip" }
 
 [profile.release]
 lto = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ harness-core = { workspace = true }
 harness-tools = { workspace = true }
 harness-memory = { workspace = true }
 harness-github = { workspace = true }
+harness-paperclip = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod auth;
 pub mod config;
 pub mod eval;
 pub mod memory;
+pub mod paperclip;
 pub mod run;
 pub mod webhook;

--- a/crates/cli/src/commands/paperclip.rs
+++ b/crates/cli/src/commands/paperclip.rs
@@ -122,8 +122,10 @@ pub async fn execute(args: PaperclipArgs) -> Result<()> {
                 .anthropic_key
                 .context("ANTHROPIC_API_KEY required for heartbeat")?;
 
+            // Build provider and memory once at the CLI level so every task
+            // reuses the same DB connection and provider instance.
             let executor: Arc<dyn TaskExecutor> =
-                Arc::new(AnvilExecutor::new(anthropic_key, cmd.model));
+                Arc::new(AnvilExecutor::build(anthropic_key, cmd.model).await?);
 
             let config = HeartbeatConfig {
                 agent_id,
@@ -143,17 +145,36 @@ pub async fn execute(args: PaperclipArgs) -> Result<()> {
 // ── Anvil executor ─────────────────────────────────────────────────────────────
 
 /// Task executor that drives a full Anvil agent session for a Paperclip task.
+///
+/// Provider, memory DB, and base config are initialised once (via [`build`])
+/// and reused across every task so that cross-task state is preserved and
+/// resources are not wasted.
 struct AnvilExecutor {
-    anthropic_key: String,
-    model: String,
+    provider: Arc<ClaudeProvider>,
+    memory: Arc<MemoryDb>,
+    config: Config,
 }
 
 impl AnvilExecutor {
-    fn new(anthropic_key: String, model: String) -> Self {
-        Self {
+    /// Build an executor, initialising the provider and memory DB exactly once.
+    async fn build(anthropic_key: String, model: String) -> Result<Self> {
+        let mut config = Config::load().unwrap_or_default();
+        config.provider.api_key = Some(anthropic_key.clone());
+        config.provider.model = model.clone();
+        config.provider.backend = "claude".to_string();
+
+        let provider = Arc::new(ClaudeProvider::new(
             anthropic_key,
             model,
-        }
+            config.provider.max_tokens,
+        ));
+        let memory = Arc::new(
+            MemoryDb::open(&config.memory.db_path)
+                .await
+                .context("open memory db for heartbeat executor")?,
+        );
+
+        Ok(Self { provider, memory, config })
     }
 
     /// Extract goal from issue description.  Uses the ## Objective section
@@ -199,24 +220,7 @@ impl TaskExecutor for AnvilExecutor {
             "Running Anvil agent for Paperclip task"
         );
 
-        // Build config, provider, and memory
-        let mut config = Config::load().unwrap_or_default();
-        config.provider.api_key = Some(self.anthropic_key.clone());
-        config.provider.model = self.model.clone();
-        config.provider.backend = "claude".to_string();
-
-        let provider = Arc::new(ClaudeProvider::new(
-            self.anthropic_key.clone(),
-            self.model.clone(),
-            config.provider.max_tokens,
-        ));
-        let memory = Arc::new(
-            MemoryDb::open(&config.memory.db_path)
-                .await
-                .context("open memory db for heartbeat executor")?,
-        );
-
-        let agent = Agent::new(provider, memory, config);
+        let agent = Agent::new(self.provider.clone(), self.memory.clone(), self.config.clone());
         let session = agent.run(&goal).await?;
 
         // Extract last assistant message text as the completion comment
@@ -242,5 +246,40 @@ impl TaskExecutor for AnvilExecutor {
         );
 
         Ok(ExecutionOutcome::Done(comment))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_goal_uses_objective_section() {
+        let desc = "## Objective\nDo the thing.\n\n## Scope\nFoo bar.";
+        let goal = AnvilExecutor::extract_goal("My Task", desc);
+        assert_eq!(goal, "My Task\n\nDo the thing.");
+    }
+
+    #[test]
+    fn extract_goal_falls_back_to_title_when_no_objective() {
+        let desc = "## Scope\nFoo bar.\n\n## Verification\n- [ ] thing";
+        let goal = AnvilExecutor::extract_goal("My Task", desc);
+        assert_eq!(goal, "My Task");
+    }
+
+    #[test]
+    fn extract_goal_falls_back_to_title_when_objective_is_empty() {
+        // Objective section exists but has no text before the next heading
+        let desc = "## Objective\n## Scope\nFoo bar.";
+        let goal = AnvilExecutor::extract_goal("My Task", desc);
+        assert_eq!(goal, "My Task");
+    }
+
+    #[test]
+    fn extract_goal_objective_at_end_of_string() {
+        // Objective is the last section — no subsequent ## heading
+        let desc = "## Scope\nFoo.\n\n## Objective\nDo the thing at the end.";
+        let goal = AnvilExecutor::extract_goal("My Task", desc);
+        assert_eq!(goal, "My Task\n\nDo the thing at the end.");
     }
 }

--- a/crates/cli/src/commands/paperclip.rs
+++ b/crates/cli/src/commands/paperclip.rs
@@ -1,0 +1,246 @@
+//! `anvil paperclip` — run Anvil as a first-class Paperclip heartbeat adapter.
+//!
+//! # Subcommands
+//!
+//! - `anvil paperclip heartbeat` — run one heartbeat cycle (inbox → work → report)
+//! - `anvil paperclip whoami`    — print agent identity and exit
+//!
+//! # Environment variables
+//!
+//! | Variable                | Description                                         |
+//! |-------------------------|-----------------------------------------------------|
+//! | `PAPERCLIP_API_URL`     | Paperclip base URL (default: http://127.0.0.1:3100) |
+//! | `PAPERCLIP_API_KEY`     | Bearer token                                        |
+//! | `PAPERCLIP_AGENT_ID`    | Agent UUID                                          |
+//! | `PAPERCLIP_COMPANY_ID`  | Company UUID                                        |
+//! | `PAPERCLIP_RUN_ID`      | Current run ID (attached to mutating requests)      |
+//! | `ANTHROPIC_API_KEY`     | Anthropic API key for the claude provider           |
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use tracing::info;
+
+use harness_core::{
+    config::Config,
+    message::{ContentBlock, MessageContent, Role},
+    providers::claude::ClaudeProvider,
+};
+use harness_memory::MemoryDb;
+use harness_paperclip::{
+    heartbeat::ExecutionOutcome, HeartbeatConfig, HeartbeatLoop, PaperclipClient, TaskExecutor,
+};
+use harness_paperclip::types::{HeartbeatContext, InboxItem};
+
+use crate::agent::Agent;
+
+// ── CLI args ───────────────────────────────────────────────────────────────────
+
+/// Paperclip control-plane integration (heartbeat, whoami)
+#[derive(Parser)]
+pub struct PaperclipArgs {
+    /// Paperclip API base URL
+    #[arg(long, env = "PAPERCLIP_API_URL", default_value = "http://127.0.0.1:3100")]
+    api_url: String,
+
+    /// Paperclip API key (bearer token)
+    #[arg(long, env = "PAPERCLIP_API_KEY")]
+    api_key: Option<String>,
+
+    /// Agent UUID
+    #[arg(long, env = "PAPERCLIP_AGENT_ID")]
+    agent_id: Option<String>,
+
+    /// Company UUID
+    #[arg(long, env = "PAPERCLIP_COMPANY_ID")]
+    company_id: Option<String>,
+
+    /// Current run ID (for audit trail headers on mutating requests)
+    #[arg(long, env = "PAPERCLIP_RUN_ID")]
+    run_id: Option<String>,
+
+    #[command(subcommand)]
+    command: PaperclipCommand,
+}
+
+#[derive(Subcommand)]
+enum PaperclipCommand {
+    /// Print agent identity and exit
+    Whoami,
+    /// Run one heartbeat cycle (poll inbox → checkout → run → report)
+    Heartbeat(HeartbeatCmd),
+}
+
+#[derive(Parser)]
+struct HeartbeatCmd {
+    /// Maximum tasks to process in this heartbeat
+    #[arg(long, default_value = "1")]
+    max_tasks: usize,
+
+    /// Anthropic API key for the claude provider
+    #[arg(long, env = "ANTHROPIC_API_KEY")]
+    anthropic_key: Option<String>,
+
+    /// Model to use
+    #[arg(long, env = "ANTHROPIC_MODEL", default_value = "claude-sonnet-4-6")]
+    model: String,
+}
+
+// ── command entry point ────────────────────────────────────────────────────────
+
+pub async fn execute(args: PaperclipArgs) -> Result<()> {
+    let api_key = args
+        .api_key
+        .context("PAPERCLIP_API_KEY is required (set env var or --api-key)")?;
+
+    let mut client = PaperclipClient::new(args.api_url.clone(), api_key);
+    if let Some(run_id) = args.run_id {
+        client = client.with_run_id(run_id);
+    }
+
+    match args.command {
+        PaperclipCommand::Whoami => {
+            let identity = client.get_identity().await?;
+            println!("Agent:   {} ({})", identity.name, identity.id);
+            println!("Company: {}", identity.company_id);
+            println!("Role:    {}", identity.role);
+            println!("Status:  {}", identity.status);
+            Ok(())
+        }
+
+        PaperclipCommand::Heartbeat(cmd) => {
+            let agent_id = args
+                .agent_id
+                .context("PAPERCLIP_AGENT_ID required for heartbeat")?;
+            let company_id = args
+                .company_id
+                .context("PAPERCLIP_COMPANY_ID required for heartbeat")?;
+
+            let anthropic_key = cmd
+                .anthropic_key
+                .context("ANTHROPIC_API_KEY required for heartbeat")?;
+
+            let executor: Arc<dyn TaskExecutor> =
+                Arc::new(AnvilExecutor::new(anthropic_key, cmd.model));
+
+            let config = HeartbeatConfig {
+                agent_id,
+                company_id,
+                max_tasks_per_wake: cmd.max_tasks,
+            };
+
+            let hb = HeartbeatLoop::new(client, config, executor);
+            let processed = hb.run_once().await?;
+            info!(processed, "Heartbeat complete");
+            println!("Heartbeat complete — {processed} task(s) processed");
+            Ok(())
+        }
+    }
+}
+
+// ── Anvil executor ─────────────────────────────────────────────────────────────
+
+/// Task executor that drives a full Anvil agent session for a Paperclip task.
+struct AnvilExecutor {
+    anthropic_key: String,
+    model: String,
+}
+
+impl AnvilExecutor {
+    fn new(anthropic_key: String, model: String) -> Self {
+        Self {
+            anthropic_key,
+            model,
+        }
+    }
+
+    /// Extract goal from issue description.  Uses the ## Objective section
+    /// from the harness spec format, falling back to the title.
+    fn extract_goal(title: &str, description: &str) -> String {
+        if let Some(idx) = description.find("## Objective") {
+            let after = &description[idx + "## Objective".len()..];
+            let paragraph: String = after
+                .lines()
+                .skip(1)
+                .take_while(|l| !l.starts_with("##"))
+                .collect::<Vec<_>>()
+                .join(" ")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            if !paragraph.is_empty() {
+                return format!("{title}\n\n{paragraph}");
+            }
+        }
+        title.to_string()
+    }
+}
+
+#[async_trait]
+impl TaskExecutor for AnvilExecutor {
+    async fn execute(
+        &self,
+        item: &InboxItem,
+        context: &HeartbeatContext,
+    ) -> Result<ExecutionOutcome> {
+        let description = context
+            .issue
+            .description
+            .as_deref()
+            .unwrap_or(item.title.as_str());
+
+        let goal = Self::extract_goal(&item.title, description);
+
+        info!(
+            issue = %item.identifier,
+            goal_preview = %goal.chars().take(120).collect::<String>(),
+            "Running Anvil agent for Paperclip task"
+        );
+
+        // Build config, provider, and memory
+        let mut config = Config::load().unwrap_or_default();
+        config.provider.api_key = Some(self.anthropic_key.clone());
+        config.provider.model = self.model.clone();
+        config.provider.backend = "claude".to_string();
+
+        let provider = Arc::new(ClaudeProvider::new(
+            self.anthropic_key.clone(),
+            self.model.clone(),
+            config.provider.max_tokens,
+        ));
+        let memory = Arc::new(
+            MemoryDb::open(&config.memory.db_path)
+                .await
+                .context("open memory db for heartbeat executor")?,
+        );
+
+        let agent = Agent::new(provider, memory, config);
+        let session = agent.run(&goal).await?;
+
+        // Extract last assistant message text as the completion comment
+        let last_assistant_text = session
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant)
+            .and_then(|m| match &m.content {
+                MessageContent::Text(t) => Some(t.clone()),
+                MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| {
+                    if let ContentBlock::Text { text } = b {
+                        Some(text.clone())
+                    } else {
+                        None
+                    }
+                }),
+            })
+            .unwrap_or_else(|| "Task complete — no assistant response recorded.".to_string());
+
+        let comment = format!(
+            "## Anvil Agent Output\n\n{last_assistant_text}\n\n---\n_Executed by `anvil paperclip heartbeat` (rust-harness)._"
+        );
+
+        Ok(ExecutionOutcome::Done(comment))
+    }
+}

--- a/crates/cli/src/commands/paperclip.rs
+++ b/crates/cli/src/commands/paperclip.rs
@@ -228,7 +228,11 @@ impl TaskExecutor for AnvilExecutor {
             "Running Anvil agent for Paperclip task"
         );
 
-        let agent = Agent::new(self.provider.clone(), self.memory.clone(), self.config.clone());
+        let agent = Agent::new(
+            self.provider.clone(),
+            self.memory.clone(),
+            self.config.clone(),
+        );
         let session = agent.run(&goal).await?;
 
         // Extract last assistant message text as the completion comment

--- a/crates/cli/src/commands/paperclip.rs
+++ b/crates/cli/src/commands/paperclip.rs
@@ -29,10 +29,10 @@ use harness_core::{
     providers::claude::ClaudeProvider,
 };
 use harness_memory::MemoryDb;
+use harness_paperclip::types::{HeartbeatContext, InboxItem};
 use harness_paperclip::{
     heartbeat::ExecutionOutcome, HeartbeatConfig, HeartbeatLoop, PaperclipClient, TaskExecutor,
 };
-use harness_paperclip::types::{HeartbeatContext, InboxItem};
 
 use crate::agent::Agent;
 
@@ -42,7 +42,11 @@ use crate::agent::Agent;
 #[derive(Parser)]
 pub struct PaperclipArgs {
     /// Paperclip API base URL
-    #[arg(long, env = "PAPERCLIP_API_URL", default_value = "http://127.0.0.1:3100")]
+    #[arg(
+        long,
+        env = "PAPERCLIP_API_URL",
+        default_value = "http://127.0.0.1:3100"
+    )]
     api_url: String,
 
     /// Paperclip API key (bearer token)
@@ -174,7 +178,11 @@ impl AnvilExecutor {
                 .context("open memory db for heartbeat executor")?,
         );
 
-        Ok(Self { provider, memory, config })
+        Ok(Self {
+            provider,
+            memory,
+            config,
+        })
     }
 
     /// Extract goal from issue description.  Uses the ## Objective section

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -31,6 +31,8 @@ enum Commands {
     Auth(commands::auth::AuthArgs),
     /// GitHub webhook integration — receive @mentions and create agent tasks
     Webhook(commands::webhook::WebhookArgs),
+    /// Paperclip control-plane integration (heartbeat, whoami)
+    Paperclip(commands::paperclip::PaperclipArgs),
 }
 
 #[tokio::main]
@@ -51,5 +53,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Eval(args) => commands::eval::execute(args).await,
         Commands::Auth(args) => commands::auth::execute(args).await,
         Commands::Webhook(args) => commands::webhook::execute(args).await,
+        Commands::Paperclip(args) => commands::paperclip::execute(args).await,
     }
 }

--- a/crates/paperclip/Cargo.toml
+++ b/crates/paperclip/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "harness-paperclip"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Paperclip control-plane client and heartbeat adapter for Anvil"
+
+[dependencies]
+# Async
+tokio = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+
+# HTTP client
+reqwest = { workspace = true }
+
+# Serialisation
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Utilities
+uuid = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/paperclip/src/client.rs
+++ b/crates/paperclip/src/client.rs
@@ -281,4 +281,36 @@ mod tests {
             .with_run_id("run-abc".into());
         assert_eq!(c.run_id.as_deref(), Some("run-abc"));
     }
+
+    /// checkout() must return Ok(None) on a 409 Conflict response so the
+    /// heartbeat loop skips the task rather than propagating an error.
+    #[tokio::test]
+    async fn checkout_returns_none_on_409() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let body = r#"{"error":"conflict"}"#;
+            let response = format!(
+                "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = PaperclipClient::new(format!("http://{addr}"), "key".into());
+        let result = client
+            .checkout("issue-1", "agent-1", &["todo"])
+            .await;
+
+        assert!(result.is_ok(), "checkout should not error on 409");
+        assert!(result.unwrap().is_none(), "checkout should return None on 409");
+    }
 }

--- a/crates/paperclip/src/client.rs
+++ b/crates/paperclip/src/client.rs
@@ -1,0 +1,284 @@
+//! Typed HTTP client for the Paperclip REST API.
+//!
+//! Covers the endpoints used by the heartbeat procedure:
+//! identity, inbox, checkout, heartbeat-context, update, comment, create-issue.
+
+use anyhow::{bail, Context, Result};
+use reqwest::{Client, StatusCode};
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::types::{
+    AddCommentRequest, AgentIdentity, CheckoutRequest, Comment, CreateIssueRequest,
+    HeartbeatContext, InboxItem, Issue, UpdateIssueRequest,
+};
+
+/// A client for the Paperclip REST API.
+///
+/// All mutating requests automatically attach `X-Paperclip-Run-Id` when
+/// `run_id` is set.
+#[derive(Clone)]
+pub struct PaperclipClient {
+    http: Client,
+    api_url: String,
+    api_key: String,
+    run_id: Option<String>,
+}
+
+impl PaperclipClient {
+    /// Create a new client.
+    ///
+    /// `api_url` — base URL (e.g. `http://127.0.0.1:3100`)
+    /// `api_key` — `PAPERCLIP_API_KEY` bearer token
+    pub fn new(api_url: String, api_key: String) -> Self {
+        Self {
+            http: Client::new(),
+            api_url,
+            api_key,
+            run_id: None,
+        }
+    }
+
+    /// Attach a run ID for audit-trail headers on mutating requests.
+    pub fn with_run_id(mut self, run_id: String) -> Self {
+        self.run_id = Some(run_id);
+        self
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    fn auth_get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", self.api_url, path);
+        debug!(url, "GET");
+        self.http.get(url).bearer_auth(&self.api_key)
+    }
+
+    fn auth_post(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", self.api_url, path);
+        debug!(url, "POST");
+        let mut req = self.http.post(url).bearer_auth(&self.api_key);
+        if let Some(rid) = &self.run_id {
+            req = req.header("X-Paperclip-Run-Id", rid);
+        }
+        req
+    }
+
+    fn auth_patch(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", self.api_url, path);
+        debug!(url, "PATCH");
+        let mut req = self.http.patch(url).bearer_auth(&self.api_key);
+        if let Some(rid) = &self.run_id {
+            req = req.header("X-Paperclip-Run-Id", rid);
+        }
+        req
+    }
+
+    async fn require_ok(resp: reqwest::Response, ctx: &str) -> Result<Value> {
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .with_context(|| format!("{ctx}: failed to parse response JSON"))?;
+
+        if !status.is_success() {
+            bail!("{ctx}: HTTP {status} — {body}");
+        }
+        Ok(body)
+    }
+
+    // ── identity ───────────────────────────────────────────────────────────
+
+    /// Step 1 — GET /api/agents/me
+    pub async fn get_identity(&self) -> Result<AgentIdentity> {
+        let resp = self
+            .auth_get("/api/agents/me")
+            .send()
+            .await
+            .context("GET /api/agents/me")?;
+        let body = Self::require_ok(resp, "get_identity").await?;
+        serde_json::from_value(body).context("deserialise AgentIdentity")
+    }
+
+    // ── inbox ──────────────────────────────────────────────────────────────
+
+    /// Step 3 — GET /api/agents/me/inbox-lite
+    pub async fn get_inbox(&self) -> Result<Vec<InboxItem>> {
+        let resp = self
+            .auth_get("/api/agents/me/inbox-lite")
+            .send()
+            .await
+            .context("GET /api/agents/me/inbox-lite")?;
+        let body = Self::require_ok(resp, "get_inbox").await?;
+        serde_json::from_value(body).context("deserialise inbox")
+    }
+
+    // ── checkout ───────────────────────────────────────────────────────────
+
+    /// Step 5 — POST /api/issues/{id}/checkout
+    ///
+    /// Returns `Ok(Some(issue))` on success, `Ok(None)` on 409 Conflict
+    /// (owned by another agent — caller should skip this task).
+    pub async fn checkout(
+        &self,
+        issue_id: &str,
+        agent_id: &str,
+        expected_statuses: &[&str],
+    ) -> Result<Option<Issue>> {
+        let payload = CheckoutRequest {
+            agent_id: agent_id.to_string(),
+            expected_statuses: expected_statuses.iter().map(|s| s.to_string()).collect(),
+        };
+
+        let resp = self
+            .auth_post(&format!("/api/issues/{issue_id}/checkout"))
+            .json(&payload)
+            .send()
+            .await
+            .context("POST checkout")?;
+
+        if resp.status() == StatusCode::CONFLICT {
+            warn!(issue_id, "Checkout 409 — owned by another agent, skipping");
+            return Ok(None);
+        }
+
+        let body = Self::require_ok(resp, "checkout").await?;
+        let issue: Issue = serde_json::from_value(body).context("deserialise checkout response")?;
+        Ok(Some(issue))
+    }
+
+    // ── heartbeat context ──────────────────────────────────────────────────
+
+    /// Step 6 — GET /api/issues/{id}/heartbeat-context
+    pub async fn get_heartbeat_context(&self, issue_id: &str) -> Result<HeartbeatContext> {
+        let resp = self
+            .auth_get(&format!("/api/issues/{issue_id}/heartbeat-context"))
+            .send()
+            .await
+            .context("GET heartbeat-context")?;
+        let body = Self::require_ok(resp, "get_heartbeat_context").await?;
+        serde_json::from_value(body).context("deserialise HeartbeatContext")
+    }
+
+    // ── comments ───────────────────────────────────────────────────────────
+
+    /// GET /api/issues/{id}/comments  (full thread)
+    pub async fn get_comments(&self, issue_id: &str) -> Result<Vec<Comment>> {
+        let resp = self
+            .auth_get(&format!("/api/issues/{issue_id}/comments"))
+            .send()
+            .await
+            .context("GET comments")?;
+        let body = Self::require_ok(resp, "get_comments").await?;
+        serde_json::from_value(body).context("deserialise comments")
+    }
+
+    /// GET /api/issues/{id}/comments?after={comment_id}&order=asc  (incremental)
+    pub async fn get_comments_after(
+        &self,
+        issue_id: &str,
+        after_comment_id: &str,
+    ) -> Result<Vec<Comment>> {
+        let resp = self
+            .auth_get(&format!(
+                "/api/issues/{issue_id}/comments?after={after_comment_id}&order=asc"
+            ))
+            .send()
+            .await
+            .context("GET comments (after)")?;
+        let body = Self::require_ok(resp, "get_comments_after").await?;
+        serde_json::from_value(body).context("deserialise comments (after)")
+    }
+
+    /// POST /api/issues/{id}/comments
+    pub async fn add_comment(&self, issue_id: &str, body: &str) -> Result<Comment> {
+        let payload = AddCommentRequest {
+            body: body.to_string(),
+        };
+        let resp = self
+            .auth_post(&format!("/api/issues/{issue_id}/comments"))
+            .json(&payload)
+            .send()
+            .await
+            .context("POST comment")?;
+        let val = Self::require_ok(resp, "add_comment").await?;
+        serde_json::from_value(val).context("deserialise comment")
+    }
+
+    // ── update issue ───────────────────────────────────────────────────────
+
+    /// PATCH /api/issues/{id}
+    pub async fn update_issue(&self, issue_id: &str, req: UpdateIssueRequest) -> Result<Issue> {
+        let resp = self
+            .auth_patch(&format!("/api/issues/{issue_id}"))
+            .json(&req)
+            .send()
+            .await
+            .context("PATCH issue")?;
+        let body = Self::require_ok(resp, "update_issue").await?;
+        serde_json::from_value(body).context("deserialise updated issue")
+    }
+
+    // ── convenience: set status + optional comment ─────────────────────────
+
+    /// Mark issue done with an optional comment.
+    pub async fn mark_done(&self, issue_id: &str, comment: Option<&str>) -> Result<Issue> {
+        self.update_issue(
+            issue_id,
+            UpdateIssueRequest {
+                status: Some("done".into()),
+                comment: comment.map(str::to_string),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Mark issue blocked with a required comment explaining the blocker.
+    pub async fn mark_blocked(&self, issue_id: &str, comment: &str) -> Result<Issue> {
+        self.update_issue(
+            issue_id,
+            UpdateIssueRequest {
+                status: Some("blocked".into()),
+                comment: Some(comment.to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    // ── create issue ───────────────────────────────────────────────────────
+
+    /// POST /api/companies/{companyId}/issues
+    pub async fn create_issue(
+        &self,
+        company_id: &str,
+        req: CreateIssueRequest,
+    ) -> Result<Issue> {
+        let resp = self
+            .auth_post(&format!("/api/companies/{company_id}/issues"))
+            .json(&req)
+            .send()
+            .await
+            .context("POST create issue")?;
+        let body = Self::require_ok(resp, "create_issue").await?;
+        serde_json::from_value(body).context("deserialise created issue")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_builds_without_run_id() {
+        let c = PaperclipClient::new("http://localhost:3100".into(), "test-key".into());
+        assert!(c.run_id.is_none());
+    }
+
+    #[test]
+    fn client_with_run_id() {
+        let c = PaperclipClient::new("http://localhost:3100".into(), "test-key".into())
+            .with_run_id("run-abc".into());
+        assert_eq!(c.run_id.as_deref(), Some("run-abc"));
+    }
+}

--- a/crates/paperclip/src/client.rs
+++ b/crates/paperclip/src/client.rs
@@ -249,11 +249,7 @@ impl PaperclipClient {
     // ── create issue ───────────────────────────────────────────────────────
 
     /// POST /api/companies/{companyId}/issues
-    pub async fn create_issue(
-        &self,
-        company_id: &str,
-        req: CreateIssueRequest,
-    ) -> Result<Issue> {
+    pub async fn create_issue(&self, company_id: &str, req: CreateIssueRequest) -> Result<Issue> {
         let resp = self
             .auth_post(&format!("/api/companies/{company_id}/issues"))
             .json(&req)
@@ -306,11 +302,12 @@ mod tests {
         });
 
         let client = PaperclipClient::new(format!("http://{addr}"), "key".into());
-        let result = client
-            .checkout("issue-1", "agent-1", &["todo"])
-            .await;
+        let result = client.checkout("issue-1", "agent-1", &["todo"]).await;
 
         assert!(result.is_ok(), "checkout should not error on 409");
-        assert!(result.unwrap().is_none(), "checkout should return None on 409");
+        assert!(
+            result.unwrap().is_none(),
+            "checkout should return None on 409"
+        );
     }
 }

--- a/crates/paperclip/src/heartbeat.rs
+++ b/crates/paperclip/src/heartbeat.rs
@@ -1,0 +1,283 @@
+//! Heartbeat loop — the core execution cycle for a Paperclip-connected agent.
+//!
+//! Follows the 9-step heartbeat procedure:
+//! 1. Identity check
+//! 2. (approval follow-up — delegated to executor)
+//! 3. Get inbox
+//! 4. Pick work (in_progress first, then todo)
+//! 5. Checkout
+//! 6. Get context
+//! 7. Execute (delegated to [`TaskExecutor`])
+//! 8. Update status + comment
+//! 9. (delegate / create subtasks — executor responsibility)
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::{info, warn};
+
+use crate::{
+    client::PaperclipClient,
+    types::{HeartbeatContext, InboxItem, IssueStatus},
+};
+
+/// Outcome of a single task execution.
+#[derive(Debug)]
+pub enum ExecutionOutcome {
+    /// Task completed successfully.  The string is the final comment body.
+    Done(String),
+    /// Task is blocked.  The string explains the blocker (who needs to act).
+    Blocked(String),
+    /// Task needs human review.  String is the comment body.
+    InReview(String),
+    /// Execution deferred — no changes were made, leave status as-is.
+    Deferred,
+}
+
+/// Trait implemented by callers to provide task execution logic.
+///
+/// The heartbeat loop handles all API ceremony (checkout, status update,
+/// comment posting).  The executor only needs to perform the actual work
+/// and return an [`ExecutionOutcome`].
+#[async_trait]
+pub trait TaskExecutor: Send + Sync {
+    /// Execute a task.
+    ///
+    /// `item` — the inbox item selected for this heartbeat
+    /// `context` — full heartbeat context (issue + ancestors + cursor)
+    async fn execute(&self, item: &InboxItem, context: &HeartbeatContext)
+        -> Result<ExecutionOutcome>;
+}
+
+/// Configuration for the heartbeat loop.
+#[derive(Debug, Clone)]
+pub struct HeartbeatConfig {
+    /// Paperclip agent ID this loop runs as.
+    pub agent_id: String,
+    /// Paperclip company ID.
+    pub company_id: String,
+    /// How many tasks to process per wake (default: 1).
+    pub max_tasks_per_wake: usize,
+}
+
+impl HeartbeatConfig {
+    pub fn new(agent_id: String, company_id: String) -> Self {
+        Self {
+            agent_id,
+            company_id,
+            max_tasks_per_wake: 1,
+        }
+    }
+}
+
+/// The heartbeat loop.
+pub struct HeartbeatLoop {
+    client: PaperclipClient,
+    config: HeartbeatConfig,
+    executor: Arc<dyn TaskExecutor>,
+}
+
+impl HeartbeatLoop {
+    pub fn new(
+        client: PaperclipClient,
+        config: HeartbeatConfig,
+        executor: Arc<dyn TaskExecutor>,
+    ) -> Self {
+        Self {
+            client,
+            config,
+            executor,
+        }
+    }
+
+    /// Run one heartbeat cycle.  Returns the number of tasks processed.
+    pub async fn run_once(&self) -> Result<usize> {
+        // Step 1: identity check (lightweight; mainly for logging)
+        let identity = self.client.get_identity().await?;
+        info!(
+            agent = %identity.name,
+            id = %identity.id,
+            "Heartbeat start"
+        );
+
+        // Step 3: inbox
+        let inbox = self.client.get_inbox().await?;
+        if inbox.is_empty() {
+            info!("Inbox empty — nothing to do");
+            return Ok(0);
+        }
+
+        // Step 4: pick work — in_progress first, then todo
+        let candidates = Self::prioritise(&inbox);
+        if candidates.is_empty() {
+            info!("No actionable tasks (all blocked/done)");
+            return Ok(0);
+        }
+
+        let mut processed = 0;
+        for item in candidates
+            .iter()
+            .take(self.config.max_tasks_per_wake)
+        {
+            if self.process_task(item).await? {
+                processed += 1;
+            }
+        }
+
+        Ok(processed)
+    }
+
+    /// Process a single task through the full heartbeat cycle.
+    /// Returns true if the task was worked on.
+    async fn process_task(&self, item: &InboxItem) -> Result<bool> {
+        info!(
+            issue = %item.identifier,
+            status = %item.status,
+            "Processing task"
+        );
+
+        // Step 5: checkout
+        let issue = self
+            .client
+            .checkout(
+                &item.id,
+                &self.config.agent_id,
+                &["todo", "backlog", "blocked", "in_progress"],
+            )
+            .await?;
+
+        let Some(_issue) = issue else {
+            warn!(issue = %item.identifier, "Checkout 409 — skipping");
+            return Ok(false);
+        };
+
+        // Step 6: heartbeat context
+        let context = match self.client.get_heartbeat_context(&item.id).await {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                warn!(issue = %item.identifier, error = %e, "Failed to get context");
+                return Ok(false);
+            }
+        };
+
+        // Step 7: execute
+        let outcome = self.executor.execute(item, &context).await;
+
+        // Step 8: update status + comment
+        match outcome {
+            Ok(ExecutionOutcome::Done(comment)) => {
+                self.client.mark_done(&item.id, Some(&comment)).await?;
+                info!(issue = %item.identifier, "Marked done");
+            }
+            Ok(ExecutionOutcome::Blocked(comment)) => {
+                self.client.mark_blocked(&item.id, &comment).await?;
+                warn!(issue = %item.identifier, "Marked blocked");
+            }
+            Ok(ExecutionOutcome::InReview(comment)) => {
+                use crate::types::UpdateIssueRequest;
+                self.client
+                    .update_issue(
+                        &item.id,
+                        UpdateIssueRequest {
+                            status: Some("in_review".into()),
+                            comment: Some(comment),
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                info!(issue = %item.identifier, "Marked in_review");
+            }
+            Ok(ExecutionOutcome::Deferred) => {
+                info!(issue = %item.identifier, "Execution deferred — no status change");
+            }
+            Err(e) => {
+                let comment = format!(
+                    "Execution error: {e}\n\nTask left in current status. Investigate and retry."
+                );
+                self.client.add_comment(&item.id, &comment).await?;
+                warn!(issue = %item.identifier, error = %e, "Execution error");
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Sort inbox items: in_progress first, then todo by priority.
+    /// Skip blocked items (they require explicit new context).
+    fn prioritise(inbox: &[InboxItem]) -> Vec<&InboxItem> {
+        let mut in_progress: Vec<&InboxItem> = inbox
+            .iter()
+            .filter(|i| i.status == IssueStatus::InProgress)
+            .collect();
+
+        let mut todo: Vec<&InboxItem> = inbox
+            .iter()
+            .filter(|i| i.status == IssueStatus::Todo || i.status == IssueStatus::Backlog)
+            .collect();
+
+        // Sort todo by priority (critical first)
+        todo.sort_by(|a, b| a.priority.cmp(&b.priority));
+
+        in_progress.append(&mut todo);
+        in_progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ActiveRun, IssuePriority};
+    use chrono::Utc;
+
+    fn make_item(status: IssueStatus, priority: IssuePriority) -> InboxItem {
+        InboxItem {
+            id: uuid::Uuid::new_v4().to_string(),
+            identifier: "TEST-1".into(),
+            title: "Test task".into(),
+            status,
+            priority,
+            project_id: None,
+            goal_id: None,
+            parent_id: None,
+            updated_at: Utc::now(),
+            active_run: None,
+        }
+    }
+
+    #[test]
+    fn prioritise_puts_in_progress_first() {
+        let items = vec![
+            make_item(IssueStatus::Todo, IssuePriority::High),
+            make_item(IssueStatus::InProgress, IssuePriority::Medium),
+            make_item(IssueStatus::Blocked, IssuePriority::Critical),
+        ];
+        let ordered = HeartbeatLoop::prioritise(&items);
+        assert_eq!(ordered.len(), 2, "blocked items excluded");
+        assert_eq!(ordered[0].status, IssueStatus::InProgress);
+        assert_eq!(ordered[1].status, IssueStatus::Todo);
+    }
+
+    #[test]
+    fn prioritise_sorts_todo_by_priority() {
+        let items = vec![
+            make_item(IssueStatus::Todo, IssuePriority::Low),
+            make_item(IssueStatus::Todo, IssuePriority::Critical),
+            make_item(IssueStatus::Todo, IssuePriority::Medium),
+        ];
+        let ordered = HeartbeatLoop::prioritise(&items);
+        assert_eq!(ordered[0].priority, IssuePriority::Critical);
+        assert_eq!(ordered[1].priority, IssuePriority::Medium);
+        assert_eq!(ordered[2].priority, IssuePriority::Low);
+    }
+
+    #[test]
+    fn prioritise_excludes_blocked() {
+        let items = vec![
+            make_item(IssueStatus::Blocked, IssuePriority::Critical),
+            make_item(IssueStatus::Blocked, IssuePriority::High),
+        ];
+        let ordered = HeartbeatLoop::prioritise(&items);
+        assert!(ordered.is_empty());
+    }
+}

--- a/crates/paperclip/src/heartbeat.rs
+++ b/crates/paperclip/src/heartbeat.rs
@@ -225,7 +225,7 @@ impl HeartbeatLoop {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ActiveRun, IssuePriority};
+    use crate::types::IssuePriority;
     use chrono::Utc;
 
     fn make_item(status: IssueStatus, priority: IssuePriority) -> InboxItem {

--- a/crates/paperclip/src/heartbeat.rs
+++ b/crates/paperclip/src/heartbeat.rs
@@ -93,11 +93,9 @@ impl HeartbeatLoop {
 
     /// Run one heartbeat cycle.  Returns the number of tasks processed.
     pub async fn run_once(&self) -> Result<usize> {
-        // Step 1: identity check (lightweight; mainly for logging)
-        let identity = self.client.get_identity().await?;
+        // Step 1: agent_id is already in config — no round-trip needed just for logging.
         info!(
-            agent = %identity.name,
-            id = %identity.id,
+            agent_id = %self.config.agent_id,
             "Heartbeat start"
         );
 
@@ -279,5 +277,94 @@ mod tests {
         ];
         let ordered = HeartbeatLoop::prioritise(&items);
         assert!(ordered.is_empty());
+    }
+
+    /// Verify that process_task posts a comment and returns Ok(true) when the
+    /// executor returns an error.  Uses a minimal in-process HTTP server to
+    /// capture the add_comment request.
+    #[tokio::test]
+    async fn process_task_posts_comment_on_executor_error() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc as StdArc;
+
+        // ---- minimal inline mock server ----
+        use tokio::net::TcpListener;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let comment_received = StdArc::new(AtomicBool::new(false));
+        let comment_received_clone = comment_received.clone();
+
+        // Spawn a bare TCP server that responds to every request with a
+        // canned JSON response (good enough for this unit test).
+        tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let mut buf = vec![0u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                // Detect the add_comment POST
+                if req.contains("POST") && req.contains("/comments") {
+                    comment_received_clone.store(true, Ordering::SeqCst);
+                }
+
+                // Respond with a valid Comment JSON for add_comment,
+                // and a valid Issue JSON for checkout + heartbeat-context.
+                let body = if req.contains("/checkout") {
+                    r#"{"id":"issue-1","companyId":"co","projectId":null,"projectWorkspaceId":null,"goalId":null,"parentId":null,"title":"T","description":null,"status":"todo","priority":"medium","assigneeAgentId":null,"assigneeUserId":null,"checkoutRunId":null,"executionRunId":null,"executionAgentNameKey":null,"executionLockedAt":null,"createdByAgentId":null,"createdByUserId":null,"issueNumber":1,"identifier":"TEST-1","originKind":"manual","originId":null,"originRunId":null,"requestDepth":0,"billingCode":null,"assigneeAdapterOverrides":null,"executionWorkspaceId":null,"executionWorkspacePreference":null,"executionWorkspaceSettings":null,"startedAt":null,"completedAt":null,"cancelledAt":null,"hiddenAt":null,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","labels":[],"labelIds":[]}"#
+                } else if req.contains("/heartbeat-context") {
+                    r#"{"issue":{"id":"issue-1","identifier":"TEST-1","title":"T","description":null,"status":"todo","priority":"medium","projectId":null,"goalId":null,"parentId":null,"assigneeAgentId":null,"assigneeUserId":null,"updatedAt":"2024-01-01T00:00:00Z"},"ancestors":[],"project":null,"goal":null,"commentCursor":{"totalComments":0,"latestCommentId":null,"latestCommentAt":null},"wakeComment":null}"#
+                } else {
+                    // add_comment response
+                    r#"{"id":"comment-1","issueId":"issue-1","body":"ok","authorAgentId":null,"authorUserId":null,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}"#
+                };
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        // ---- executor that always errors ----
+        struct FailExecutor;
+        #[async_trait]
+        impl TaskExecutor for FailExecutor {
+            async fn execute(
+                &self,
+                _item: &InboxItem,
+                _context: &HeartbeatContext,
+            ) -> Result<ExecutionOutcome> {
+                Err(anyhow::anyhow!("simulated executor failure"))
+            }
+        }
+
+        let client = PaperclipClient::new(
+            format!("http://{addr}"),
+            "test-key".into(),
+        );
+        let config = HeartbeatConfig {
+            agent_id: "agent-1".into(),
+            company_id: "co-1".into(),
+            max_tasks_per_wake: 1,
+        };
+        let loop_ = HeartbeatLoop::new(client, config, StdArc::new(FailExecutor));
+
+        let item = make_item(IssueStatus::Todo, IssuePriority::Medium);
+        // Override id to match mock
+        let mut item = item;
+        item.id = "issue-1".into();
+
+        let result = loop_.process_task(&item).await;
+        assert!(result.is_ok(), "process_task should not propagate executor error");
+        assert!(result.unwrap(), "process_task should return true even on executor error");
+        assert!(comment_received.load(Ordering::SeqCst), "should have posted a comment");
     }
 }

--- a/crates/paperclip/src/heartbeat.rs
+++ b/crates/paperclip/src/heartbeat.rs
@@ -46,8 +46,11 @@ pub trait TaskExecutor: Send + Sync {
     ///
     /// `item` — the inbox item selected for this heartbeat
     /// `context` — full heartbeat context (issue + ancestors + cursor)
-    async fn execute(&self, item: &InboxItem, context: &HeartbeatContext)
-        -> Result<ExecutionOutcome>;
+    async fn execute(
+        &self,
+        item: &InboxItem,
+        context: &HeartbeatContext,
+    ) -> Result<ExecutionOutcome>;
 }
 
 /// Configuration for the heartbeat loop.
@@ -114,10 +117,7 @@ impl HeartbeatLoop {
         }
 
         let mut processed = 0;
-        for item in candidates
-            .iter()
-            .take(self.config.max_tasks_per_wake)
-        {
+        for item in candidates.iter().take(self.config.max_tasks_per_wake) {
             if self.process_task(item).await? {
                 processed += 1;
             }

--- a/crates/paperclip/src/heartbeat.rs
+++ b/crates/paperclip/src/heartbeat.rs
@@ -288,8 +288,8 @@ mod tests {
         use std::sync::Arc as StdArc;
 
         // ---- minimal inline mock server ----
-        use tokio::net::TcpListener;
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -318,7 +318,7 @@ mod tests {
                 let body = if req.contains("/checkout") {
                     r#"{"id":"issue-1","companyId":"co","projectId":null,"projectWorkspaceId":null,"goalId":null,"parentId":null,"title":"T","description":null,"status":"todo","priority":"medium","assigneeAgentId":null,"assigneeUserId":null,"checkoutRunId":null,"executionRunId":null,"executionAgentNameKey":null,"executionLockedAt":null,"createdByAgentId":null,"createdByUserId":null,"issueNumber":1,"identifier":"TEST-1","originKind":"manual","originId":null,"originRunId":null,"requestDepth":0,"billingCode":null,"assigneeAdapterOverrides":null,"executionWorkspaceId":null,"executionWorkspacePreference":null,"executionWorkspaceSettings":null,"startedAt":null,"completedAt":null,"cancelledAt":null,"hiddenAt":null,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","labels":[],"labelIds":[]}"#
                 } else if req.contains("/heartbeat-context") {
-                    r#"{"issue":{"id":"issue-1","identifier":"TEST-1","title":"T","description":null,"status":"todo","priority":"medium","projectId":null,"goalId":null,"parentId":null,"assigneeAgentId":null,"assigneeUserId":null,"updatedAt":"2024-01-01T00:00:00Z"},"ancestors":[],"project":null,"goal":null,"commentCursor":{"totalComments":0,"latestCommentId":null,"latestCommentAt":null},"wakeComment":null}"#
+                    r#"{"issue":{"id":"issue-1","identifier":"TEST-1","title":"T","description":null,"status":"todo","priority":"medium","projectId":null,"goalId":null,"parentId":null,"assigneeAgentId":null,"assigneeUserId":null,"updatedAt":"2024-01-01T00:00:00Z","createdAt":"2024-01-01T00:00:00Z"},"ancestors":[],"project":null,"goal":null,"commentCursor":{"totalComments":0,"latestCommentId":null,"latestCommentAt":null},"wakeComment":null}"#
                 } else {
                     // add_comment response
                     r#"{"id":"comment-1","issueId":"issue-1","body":"ok","authorAgentId":null,"authorUserId":null,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}"#
@@ -346,10 +346,7 @@ mod tests {
             }
         }
 
-        let client = PaperclipClient::new(
-            format!("http://{addr}"),
-            "test-key".into(),
-        );
+        let client = PaperclipClient::new(format!("http://{addr}"), "test-key".into());
         let config = HeartbeatConfig {
             agent_id: "agent-1".into(),
             company_id: "co-1".into(),
@@ -363,8 +360,17 @@ mod tests {
         item.id = "issue-1".into();
 
         let result = loop_.process_task(&item).await;
-        assert!(result.is_ok(), "process_task should not propagate executor error");
-        assert!(result.unwrap(), "process_task should return true even on executor error");
-        assert!(comment_received.load(Ordering::SeqCst), "should have posted a comment");
+        assert!(
+            result.is_ok(),
+            "process_task should not propagate executor error"
+        );
+        assert!(
+            result.unwrap(),
+            "process_task should return true even on executor error"
+        );
+        assert!(
+            comment_received.load(Ordering::SeqCst),
+            "should have posted a comment"
+        );
     }
 }

--- a/crates/paperclip/src/lib.rs
+++ b/crates/paperclip/src/lib.rs
@@ -1,0 +1,33 @@
+//! Paperclip control-plane client and heartbeat adapter for Anvil.
+//!
+//! This crate provides:
+//! - [`PaperclipClient`] — typed HTTP client for the Paperclip REST API
+//! - [`HeartbeatLoop`] — full heartbeat cycle: poll inbox → checkout → run → report
+//! - [`types`] — shared API types (Agent, Issue, InboxItem, …)
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use harness_paperclip::{PaperclipClient, HeartbeatLoop, HeartbeatConfig};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let client = PaperclipClient::new(
+//!         "http://127.0.0.1:3100".into(),
+//!         std::env::var("PAPERCLIP_API_KEY")?,
+//!     );
+//!     let identity = client.get_identity().await?;
+//!     println!("Running as: {} ({})", identity.name, identity.id);
+//!     Ok(())
+//! }
+//! ```
+
+#![allow(clippy::pedantic)]
+#![forbid(unsafe_code)]
+
+pub mod client;
+pub mod heartbeat;
+pub mod types;
+
+pub use client::PaperclipClient;
+pub use heartbeat::{HeartbeatConfig, HeartbeatLoop, TaskExecutor};

--- a/crates/paperclip/src/types.rs
+++ b/crates/paperclip/src/types.rs
@@ -1,0 +1,204 @@
+//! Paperclip API response and request types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Agent identity returned by GET /api/agents/me
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentIdentity {
+    pub id: String,
+    pub company_id: String,
+    pub name: String,
+    pub role: String,
+    pub status: String,
+    pub budget_monthly_cents: i64,
+    pub spent_monthly_cents: i64,
+    pub url_key: String,
+    #[serde(default)]
+    pub chain_of_command: Vec<ChainMember>,
+}
+
+/// A single entry in the agent chain of command.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainMember {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+}
+
+/// Compact inbox item returned by GET /api/agents/me/inbox-lite
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxItem {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub status: IssueStatus,
+    pub priority: IssuePriority,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub goal_id: Option<String>,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub active_run: Option<ActiveRun>,
+}
+
+/// Minimal active-run info embedded in an InboxItem.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveRun {
+    pub id: String,
+    pub status: String,
+    pub agent_id: String,
+}
+
+/// Full issue object.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Issue {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: IssueStatus,
+    pub priority: IssuePriority,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub goal_id: Option<String>,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    #[serde(default)]
+    pub assignee_agent_id: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Issue comment.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Comment {
+    pub id: String,
+    pub issue_id: String,
+    pub body: String,
+    #[serde(default)]
+    pub author_agent_id: Option<String>,
+    #[serde(default)]
+    pub author_user_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Compact heartbeat context returned by GET /api/issues/{id}/heartbeat-context
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatContext {
+    pub issue: Issue,
+    #[serde(default)]
+    pub ancestors: Vec<Issue>,
+    pub comment_cursor: CommentCursor,
+}
+
+/// Comment cursor metadata in heartbeat context.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentCursor {
+    pub total_comments: u32,
+    #[serde(default)]
+    pub latest_comment_id: Option<String>,
+    #[serde(default)]
+    pub latest_comment_at: Option<DateTime<Utc>>,
+}
+
+/// Issue status values.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueStatus {
+    Backlog,
+    Todo,
+    InProgress,
+    InReview,
+    Done,
+    Blocked,
+    Cancelled,
+    #[serde(other)]
+    Unknown,
+}
+
+impl std::fmt::Display for IssueStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IssueStatus::Backlog => write!(f, "backlog"),
+            IssueStatus::Todo => write!(f, "todo"),
+            IssueStatus::InProgress => write!(f, "in_progress"),
+            IssueStatus::InReview => write!(f, "in_review"),
+            IssueStatus::Done => write!(f, "done"),
+            IssueStatus::Blocked => write!(f, "blocked"),
+            IssueStatus::Cancelled => write!(f, "cancelled"),
+            IssueStatus::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Issue priority values.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssuePriority {
+    Critical,
+    High,
+    Medium,
+    Low,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Request body for checkout.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckoutRequest {
+    pub agent_id: String,
+    pub expected_statuses: Vec<String>,
+}
+
+/// Request body for PATCH /api/issues/{id}.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateIssueRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee_agent_id: Option<String>,
+}
+
+/// Request body for POST /api/issues/{id}/comments.
+#[derive(Debug, Serialize)]
+pub struct AddCommentRequest {
+    pub body: String,
+}
+
+/// Request body for creating a new issue.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateIssueRequest {
+    pub title: String,
+    pub description: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee_agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}


### PR DESCRIPTION
## Thinking Path

1. **ANGA-70** — epic: Fork Claude Code → build rust agent harness. Board vision: Paperclip-as-single-agent-harness.
2. Phases 1–6 complete: scaffold, tool-call loop, streaming, sub-agents, CI, self-evolution engine.
3. **Phase 7** — Control Plane + Paperclip Integration. First milestone: make Anvil a first-class Paperclip heartbeat adapter.
4. Existing codebase has `harness-github` with a minimal `PaperclipClient`. Phase 7a expands this into a full `harness-paperclip` crate covering the complete 9-step heartbeat procedure.
5. New `harness-paperclip` crate: typed HTTP client + heartbeat loop + `TaskExecutor` trait for pluggable task execution.
6. New `anvil paperclip` CLI command: `whoami` (identity check) and `heartbeat` (full cycle using Anvil agent session per task).
7. Workspace Cargo.toml updated; `harness-cli` depends on `harness-paperclip`.
8. **ANGA-330 (P1/P2 code review fixes)**: code review found resource waste and missing coverage — fixed in follow-up commit `1b2ec89`.

## What Changed

### Phase 7a — `harness-paperclip` crate + `anvil paperclip` CLI (commit `9109c8b`)

- **`crates/paperclip/`** (new crate: `harness-paperclip`)
  - `types.rs` — `AgentIdentity`, `InboxItem`, `Issue`, `Comment`, `HeartbeatContext`, `IssueStatus`, `IssuePriority`, request/response structs
  - `client.rs` — `PaperclipClient`: typed HTTP client for heartbeat procedure endpoints. Attaches `X-Paperclip-Run-Id` on all mutating requests. Gracefully returns `Ok(None)` on 409 checkout conflicts.
  - `heartbeat.rs` — `HeartbeatLoop` + `TaskExecutor` trait: full heartbeat cycle (identity → inbox → prioritise → checkout → execute → report). Prioritises `in_progress` → `todo` by priority. Skips blocked tasks.
  - `lib.rs` — public API + doc example
- **`crates/cli/src/commands/paperclip.rs`** (new) — `anvil paperclip whoami` and `anvil paperclip heartbeat` with `AnvilExecutor` driving a real Anvil agent session
- **`crates/cli/src/main.rs`** — added `Paperclip` command variant
- **`crates/cli/src/commands/mod.rs`** — added `paperclip` module
- **`crates/cli/Cargo.toml`** — added `harness-paperclip` dep
- **`Cargo.toml`** — added `harness-paperclip` to workspace deps

### ANGA-330 — P1/P2 code review fixes (commit `1b2ec89`)

- **P1 — `AnvilExecutor` restructured** (`crates/cli/src/commands/paperclip.rs`): `Config`, `ClaudeProvider`, and `MemoryDb` were re-created on every task inside `execute()`. Moved to `AnvilExecutor::build()` (async constructor), stored as `Arc` fields. Now initialised once, shared across all tasks.
- **P1 — Removed `get_identity()` from `HeartbeatLoop::run_once()`** (`crates/paperclip/src/heartbeat.rs`): was called only for a log line; `agent_id` is already in `HeartbeatConfig`. Eliminated the unnecessary round-trip.
- **P2 — Added test coverage**:
  - `checkout()` returns `Ok(None)` on 409 Conflict (inline TCP mock, no external deps)
  - `extract_goal()` edge cases: no Objective section, empty Objective, Objective at end of string
  - `process_task()` posts a comment and returns `Ok(true)` when executor errors

## Verification

```bash
cargo check --workspace   # PASS
cargo test --workspace    # PASS (55+ tests including new P2 coverage)
cargo clippy --workspace  # PASS
```

## Risks

- Low risk: additive change, no existing code paths modified.
- `AnvilExecutor` always marks tasks `Done`; a richer executor should inspect output for Done/Blocked/InReview. Tracked as follow-up.

## Checklist

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] No `unwrap()` or `expect()` outside tests
- [x] `X-Paperclip-Run-Id` attached to all mutating API calls
- [x] 409 checkout conflicts handled gracefully
- [x] P1/P2 code review issues resolved (ANGA-330)
- [x] Co-authored by Paperclip

Closes ANGA-330
