### PR TITLE
feat(assets): Anvil brand identity — logo, icon, mascot

### DIFF
--- a/assets/anvil-icon.svg
+++ b/assets/anvil-icon.svg
@@ -1,38 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Anvil icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
   <!--
-    Anvil icon — 64×64, legible at 32×32.
-    Palette: #2D3748 body, #4A5568 face, #718096 highlights.
-    Anatomy: two feet → waist trapezoid → table body → top face → horn.
-    Hardy hole rendered as a semi-transparent overlay (theme-safe).
-    Scale factor: 0.64 of the 100×100 base grid, centered in 64×64 canvas.
+    anvil-icon.svg — 64×64 icon variant, legible at 32×32
+    Palette: #2D3748 body, #4A5568 face/top, #718096 highlights
   -->
-  <g transform="translate(0, 2) scale(0.64)">
 
-    <!-- Feet -->
-    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
-    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+  <!-- Left foot -->
+  <rect x="8" y="50" width="18" height="10" rx="1.5" fill="#2D3748"/>
+  <!-- Right foot -->
+  <rect x="38" y="50" width="18" height="10" rx="1.5" fill="#2D3748"/>
 
-    <!-- Waist -->
-    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+  <!-- Waist — narrows from body to feet -->
+  <path d="M12,39 L52,39 L48,50 L16,50 Z" fill="#2D3748"/>
 
-    <!-- Table body -->
-    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+  <!-- Body — main rectangular block -->
+  <rect x="8" y="15" width="48" height="24" fill="#2D3748"/>
 
-    <!-- Top face -->
-    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
+  <!-- Horn — left-pointing taper extending from body -->
+  <path d="M8,15 L8,27 L1,21 Z" fill="#2D3748"/>
 
-    <!-- Hardy hole -->
-    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
+  <!-- Work face — flat top surface, lighter to show the working plane -->
+  <rect x="8" y="8" width="48" height="7" rx="1.5" fill="#4A5568"/>
 
-    <!-- Horn -->
-    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
+  <!-- Highlight stripe across left portion of face top -->
+  <rect x="8" y="8" width="32" height="2" rx="1" fill="#718096"/>
 
-    <!-- Horn edge highlight -->
-    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1.2" fill="none" opacity="0.6"/>
-
-    <!-- Table right-edge highlight -->
-    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none"
-          stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
-
-  </g>
+  <!-- Hardy hole — square tool socket near right of face -->
+  <rect x="48" y="9" width="6" height="5" rx="0.5" fill="#1A202C"/>
 </svg>

--- a/assets/anvil-logo.svg
+++ b/assets/anvil-logo.svg
@@ -1,83 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 100" role="img" aria-label="Anvil">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 100" fill="none">
   <!--
-    Anvil — provider-agnostic Rust AI agent runtime
-    Logo lockup: icon (left) + wordmark (right)
-    Palette: #2D3748 body, #4A5568 face, #718096 highlights
-
-    Icon anatomy (scaled to fit left 80px, centered vertically in 100px):
-      - Top face: flat work surface
-      - Horn: left-pointing taper off the table
-      - Table body: hexagonal platform
-      - Waist: trapezoid taper
-      - Feet: two rectangular feet
-      - Hardy hole: small cutout in the table
+    anvil-logo.svg — 240×100 logo with wordmark
+    Left zone (0–88): anvil icon silhouette
+    Divider at x=95
+    Right zone (103–232): "anvil" wordmark, stroke-based embedded paths
+    Palette: #2D3748 body/text, #4A5568 face/top, #718096 highlights
   -->
 
-  <!-- === ICON (scale 0.72 of 100x100 base, translate to center in 100x100 left zone) === -->
-  <g transform="translate(6, 4) scale(0.72)">
+  <!-- === ANVIL ICON === -->
 
-    <!-- Feet -->
-    <rect x="18" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
-    <rect x="57" y="83" width="25" height="9" rx="2" fill="#2D3748"/>
+  <!-- Left foot -->
+  <rect x="8" y="65" width="22" height="13" rx="2" fill="#2D3748"/>
+  <!-- Right foot -->
+  <rect x="46" y="65" width="22" height="13" rx="2" fill="#2D3748"/>
 
-    <!-- Waist -->
-    <path d="M28 73 L72 73 L65 83 L35 83 Z" fill="#2D3748"/>
+  <!-- Waist — trapezoid connecting body to feet -->
+  <path d="M15,51 L65,51 L60,65 L20,65 Z" fill="#2D3748"/>
 
-    <!-- Table body -->
-    <path d="M20 57 L80 57 L80 65 L72 73 L28 73 L20 65 Z" fill="#2D3748"/>
+  <!-- Body — main block -->
+  <rect x="10" y="21" width="60" height="30" fill="#2D3748"/>
 
-    <!-- Table top face highlight -->
-    <rect x="19" y="53" width="62" height="4.5" rx="1.5" fill="#4A5568"/>
+  <!-- Horn — left-pointing taper -->
+  <path d="M10,21 L10,36 L1,28 Z" fill="#2D3748"/>
 
-    <!-- Hardy hole cutout -->
-    <rect x="65" y="58.5" width="8" height="6" rx="1" fill="#718096" opacity="0.35"/>
+  <!-- Work face — flat top surface, lighter tone -->
+  <rect x="8" y="12" width="64" height="9" rx="2" fill="#4A5568"/>
 
-    <!-- Horn -->
-    <path d="M20 57 L20 65 L4 62 Z" fill="#2D3748"/>
+  <!-- Highlight stripe on face -->
+  <rect x="8" y="12" width="42" height="3" rx="1.5" fill="#718096"/>
 
-    <!-- Horn tip edge highlight -->
-    <path d="M20 57 L4 62" stroke="#718096" stroke-width="1" fill="none" opacity="0.6"/>
-
-    <!-- Table edge highlight (right side) -->
-    <path d="M80 57 L80 65 L72 73" stroke="#718096" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
-
-  </g>
+  <!-- Hardy hole -->
+  <rect x="63" y="13" width="8" height="6" rx="1" fill="#1A202C"/>
 
   <!-- Divider -->
-  <line x1="82" y1="18" x2="82" y2="82" stroke="#2D3748" stroke-width="1" opacity="0.15"/>
+  <line x1="88" y1="14" x2="88" y2="86"
+        stroke="#4A5568" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
 
+  <!-- === WORDMARK "anvil" — stroke-based embedded letterforms === -->
   <!--
-    === WORDMARK: "anvil" ===
-    Stroke-based geometric sans letterforms.
-    Cap height: 30px. Baseline: y=62. Start: x=93.
-    Stroke: width=4.5, round caps+joins.
-
-    a — circle bowl + right descender stem
-    n — left stem + arch + right stem
-    v — chevron
-    i — stem + dot
-    l — tall stem
+    Cap height: y=36–68 (32px). Stroke-width=5, round caps+joins.
+    a: bowl center (131,50) r=14; open gap at right; stem x=145, y=36–68
+    n: left stem x=157; arch M157,46 cubic to x=175,46; right stem y=46–68
+    v: chevron 183,36 → 192,68 → 201,36
+    i: stem x=209 y=46–68; dot cy=32 r=3.5
+    l: tall stem x=217 y=18–68
   -->
-  <g fill="none" stroke="#2D3748" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
+  <g fill="none" stroke="#2D3748" stroke-width="5"
+     stroke-linecap="round" stroke-linejoin="round">
 
-    <!-- a: bowl (center 104,52, r=10) open right side + descending stem -->
-    <path d="M114 52 A10 10 0 1 0 114 54"/>
-    <line x1="114" y1="42" x2="114" y2="63"/>
+    <!-- a: nearly-full circle opening on right, plus right stem -->
+    <path d="M145,49 A14 14 0 1 0 145,51"/>
+    <line x1="145" y1="36" x2="145" y2="68"/>
 
-    <!-- n: left stem + arch + right stem -->
-    <line x1="127" y1="42" x2="127" y2="63"/>
-    <path d="M127 47 C127 39 135 39 135 39 C143 39 143 47 143 47 L143 63"/>
+    <!-- n: left stem + arched top + right descent -->
+    <line x1="157" y1="36" x2="157" y2="68"/>
+    <path d="M157,46 C157,36 175,36 175,46 L175,68"/>
 
-    <!-- v: two converging legs -->
-    <polyline points="150,41 158,63 166,41"/>
+    <!-- v: two diagonals meeting at baseline midpoint -->
+    <polyline points="183,36 192,68 201,36"/>
 
-    <!-- i: stem + dot -->
-    <line x1="174" y1="49" x2="174" y2="63"/>
-    <circle cx="174" cy="40" r="2.8" fill="#2D3748" stroke="none"/>
+    <!-- i: short stem + dot above -->
+    <line x1="209" y1="46" x2="209" y2="68"/>
+    <circle cx="209" cy="32" r="3.5" fill="#2D3748" stroke="none"/>
 
-    <!-- l: tall stem -->
-    <line x1="184" y1="30" x2="184" y2="63"/>
+    <!-- l: tall stem extending above cap height -->
+    <line x1="217" y1="18" x2="217" y2="68"/>
 
   </g>
-
 </svg>

--- a/assets/anvil-mascot.svg
+++ b/assets/anvil-mascot.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
+  <!--
+    anvil-mascot.svg — "Anvi" the Anvil character
+    Personified anvil: strong, clever, approachable.
+    Works at 200×200 and scales up cleanly.
+    Palette: #2D3748 body, #4A5568 face/top, #718096 highlights
+             white eyes, #1A202C pupils, #E07070 blush cheeks
+  -->
+
+  <!-- === ANVIL BODY === -->
+
+  <!-- Left foot -->
+  <rect x="36" y="141" width="52" height="28" rx="4" fill="#2D3748"/>
+  <!-- Right foot -->
+  <rect x="112" y="141" width="52" height="28" rx="4" fill="#2D3748"/>
+
+  <!-- Waist — trapezoid bridging body to feet -->
+  <path d="M50,117 L150,117 L140,141 L60,141 Z" fill="#2D3748"/>
+
+  <!-- Body — main rectangular block -->
+  <rect x="44" y="47" width="112" height="70" fill="#2D3748"/>
+
+  <!-- Body left highlight — subtle metallic edge -->
+  <rect x="44" y="47" width="3" height="70" fill="#718096" opacity="0.2"/>
+
+  <!-- Horn — bold taper extending left from body -->
+  <path d="M44,47 L44,87 L16,67 Z" fill="#2D3748"/>
+
+  <!-- Sparkle at horn tip — sharp and clever -->
+  <path d="M16,61 L16,73 M10,67 L22,67"
+        stroke="#718096" stroke-width="2.5" stroke-linecap="round" opacity="0.65"/>
+
+  <!-- Work face — flat top surface, lighter tone -->
+  <rect x="40" y="31" width="120" height="16" rx="3" fill="#4A5568"/>
+
+  <!-- Highlight stripe on face (left two-thirds) -->
+  <rect x="40" y="31" width="80" height="4" rx="2" fill="#718096"/>
+
+  <!-- Hardy hole — square socket near right of face -->
+  <rect x="142" y="33" width="14" height="12" rx="2" fill="#1A202C"/>
+
+  <!-- === ARMS — thick rounded strokes giving a stocky strong look === -->
+  <path d="M44,72 Q18,90 12,118"
+        stroke="#2D3748" stroke-width="14" stroke-linecap="round" fill="none"/>
+  <path d="M156,72 Q182,90 188,118"
+        stroke="#2D3748" stroke-width="14" stroke-linecap="round" fill="none"/>
+
+  <!-- === CHARACTER FACE (on body front surface) === -->
+
+  <!-- Left eye -->
+  <ellipse cx="84" cy="79" rx="10" ry="11" fill="white"/>
+  <circle cx="87" cy="82" r="6" fill="#1A202C"/>
+  <!-- Left eye shine -->
+  <circle cx="83" cy="75" r="2.5" fill="white"/>
+
+  <!-- Right eye -->
+  <ellipse cx="116" cy="79" rx="10" ry="11" fill="white"/>
+  <circle cx="119" cy="82" r="6" fill="#1A202C"/>
+  <!-- Right eye shine -->
+  <circle cx="115" cy="75" r="2.5" fill="white"/>
+
+  <!-- Cheeks — warm blush for approachability -->
+  <circle cx="70" cy="91" r="9" fill="#E07070" opacity="0.35"/>
+  <circle cx="130" cy="91" r="9" fill="#E07070" opacity="0.35"/>
+
+  <!-- Eyebrows — confident raised arch -->
+  <path d="M76,68 Q84,60 92,68"
+        stroke="#718096" stroke-width="3.5" stroke-linecap="round" fill="none"/>
+  <path d="M108,68 Q116,60 124,68"
+        stroke="#718096" stroke-width="3.5" stroke-linecap="round" fill="none"/>
+
+  <!-- Smile — wide friendly curve -->
+  <path d="M83,100 Q100,115 117,100"
+        stroke="white" stroke-width="4" stroke-linecap="round" fill="none"/>
+
+</svg>


### PR DESCRIPTION
Closing in favor of PR #35 which rebases cleanly onto dev after the logo redesign (PR #32) was merged.