### PR TITLE
fix(memory): sanitize FTS5 query terms to prevent syntax errors (ANGA-337)

### DIFF
--- a/crates/memory/src/db.rs
+++ b/crates/memory/src/db.rs
@@ -344,7 +344,10 @@ mod tests {
 
         // Goal strings with trailing punctuation must not cause FTS5 syntax errors.
         let results = db.search("features. what can you do,", 10).await;
-        assert!(results.is_ok(), "punctuated query should not fail: {results:?}");
+        assert!(
+            results.is_ok(),
+            "punctuated query should not fail: {results:?}"
+        );
         assert_eq!(results.unwrap().len(), 1);
     }
 
@@ -353,7 +356,10 @@ mod tests {
         let db = MemoryDb::in_memory().await.unwrap();
         // A query made entirely of punctuation produces no valid FTS5 terms.
         let results = db.search("... !!! ---", 10).await;
-        assert!(results.is_ok(), "all-punctuation query should not fail: {results:?}");
+        assert!(
+            results.is_ok(),
+            "all-punctuation query should not fail: {results:?}"
+        );
         assert_eq!(results.unwrap().len(), 0);
     }
 }

--- a/crates/memory/src/db.rs
+++ b/crates/memory/src/db.rs
@@ -214,9 +214,27 @@ impl MemoryDb {
     /// syntax so that a multi-word goal like "explain rust ownership" matches
     /// episodes that contain any of those words rather than requiring all of
     /// them to be present.
+    ///
+    /// Each term is sanitized to strip characters that FTS5 rejects (e.g. a
+    /// trailing period in `"features."` produces `fts5: syntax error near "."`).
+    /// Only alphanumeric characters and underscores survive; empty terms after
+    /// sanitization are dropped. If no valid terms remain, returns an empty vec.
     pub async fn search(&self, query: &str, limit: i64) -> Result<Vec<Episode>> {
-        // Convert "explain rust ownership" -> "explain OR rust OR ownership"
-        let fts_query = query.split_whitespace().collect::<Vec<_>>().join(" OR ");
+        // Strip FTS5-incompatible characters from each whitespace-delimited token.
+        let fts_query = query
+            .split_whitespace()
+            .map(|term| {
+                term.chars()
+                    .filter(|c| c.is_alphanumeric() || *c == '_')
+                    .collect::<String>()
+            })
+            .filter(|term| !term.is_empty())
+            .collect::<Vec<_>>()
+            .join(" OR ");
+
+        if fts_query.is_empty() {
+            return Ok(Vec::new());
+        }
 
         let rows = sqlx::query(
             r#"SELECT e.id, e.session_id, e.kind, e.role, e.content, e.metadata, e.created_at
@@ -315,5 +333,27 @@ mod tests {
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].content, "message 0");
         assert_eq!(results[2].content, "message 2");
+    }
+
+    #[tokio::test]
+    async fn search_tolerates_punctuation() {
+        let db = MemoryDb::in_memory().await.unwrap();
+        let session_id = Uuid::new_v4();
+        let ep = crate::Episode::turn(session_id, "user", "overview of features");
+        db.insert(&ep).await.unwrap();
+
+        // Goal strings with trailing punctuation must not cause FTS5 syntax errors.
+        let results = db.search("features. what can you do,", 10).await;
+        assert!(results.is_ok(), "punctuated query should not fail: {results:?}");
+        assert_eq!(results.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn search_empty_after_sanitization_returns_empty() {
+        let db = MemoryDb::in_memory().await.unwrap();
+        // A query made entirely of punctuation produces no valid FTS5 terms.
+        let results = db.search("... !!! ---", 10).await;
+        assert!(results.is_ok(), "all-punctuation query should not fail: {results:?}");
+        assert_eq!(results.unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
## Thinking Path

1. ANGA-337: anvil run warned: fts5: syntax error near "." — memory search failed and proceeding without recall
2. The goal text passed by the user contained a period ("give me an overview of your features. what you can do..."), which FTS5 interprets as a query operator
3. Traced to MemoryDb::search() in crates/memory/src/db.rs — raw user text was passed directly to FTS5 MATCH without sanitization
4. FTS5 syntax: each search term must be an alphanumeric token or quoted phrase; punctuation like "." breaks the query
5. Fix: split input into whitespace-delimited tokens, strip non-alphanumeric/non-underscore chars from each token, filter empty tokens, rejoin — produces a clean MATCH expression
6. CTO reviewed the fix on 2026-04-04 and accepted it; branch was ready but PR creation was not completed in the previous heartbeat

## What Changed

-  — : added  helper that strips punctuation from each whitespace-split token before passing to SQLite FTS5 MATCH

## Verification



## Risks

- Low risk: only affects memory search query construction, not storage or retrieval logic
- Edge case: goals with only punctuation produce an empty query string — the fix returns Ok(vec![]) instead of erroring, which is acceptable (proceed without recall)
- Note: branch is 13 commits behind dev; may need rebase if db.rs changed on dev

## Checklist

- [x] feature/* → dev branch model
- [x] Conventional commit format: fix(memory): ...
- [x] Co-authored by Paperclip
- [x] CTO review accepted (2026-04-04T04:15:22)
- [ ] cargo test — awaiting board verification (cargo unavailable in agent env)
