### PR TITLE
test(cli): add echo provider integration test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,39 @@ cargo fmt --check
 cargo audit
 ```
 
+### Testing with the echo provider
+
+The `EchoProvider` enables full end-to-end testing without any LLM API key or credits:
+
+```bash
+# Run the agent loop with the echo provider (mirrors input back)
+anvil run --provider echo --goal "test task"
+
+# Run the full integration test suite (uses echo provider, no API key needed)
+cargo test -p harness-cli --test echo_integration
+```
+
+**Scripted tool calls:** For tests that need deterministic tool-call behaviour,
+use `EchoProvider::scripted()` to queue tool calls that are emitted in order
+before falling back to the normal echo response:
+
+```rust
+use harness_core::provider::{EchoProvider, ScriptedToolCall};
+
+let provider = EchoProvider::scripted(vec![
+    ScriptedToolCall {
+        id: "call-1".to_string(),
+        name: "echo".to_string(),
+        input: serde_json::json!({"message": "ping"}),
+    },
+]);
+// First provider call returns ToolUse; subsequent calls echo normally.
+```
+
+Integration tests live in `crates/cli/tests/echo_integration.rs` and cover:
+plain echo, scripted tool dispatch, max-iteration caps, memory persistence,
+and named-session continuity.
+
 ### Commit style
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lib]
+name = "harness_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "anvil"
 path = "src/main.rs"

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -42,7 +42,7 @@ async fn check_connectivity(config: &Config) {
     let backend = &config.provider.backend;
 
     let provider: Result<Arc<dyn Provider>, String> = match backend.as_str() {
-        "echo" => Ok(Arc::new(EchoProvider)),
+        "echo" => Ok(Arc::new(EchoProvider::new())),
         "claude-code" | "cc" => Ok(Arc::new(ClaudeCodeProvider::new(&config.provider.model))),
         _ => ClaudeProvider::from_env(&config.provider.model, config.provider.max_tokens)
             .map(|p| Arc::new(p) as Arc<dyn Provider>)

--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -63,7 +63,7 @@ pub async fn execute(args: EvalArgs) -> anyhow::Result<()> {
     let provider: Arc<dyn Provider> = match backend.as_str() {
         "echo" => {
             tracing::info!("using echo provider (no LLM calls)");
-            Arc::new(harness_core::provider::EchoProvider)
+            Arc::new(harness_core::provider::EchoProvider::new())
         }
         _ => {
             let api_key = config.resolved_api_key().ok_or_else(|| {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -112,7 +112,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     let provider: Arc<dyn Provider> = match backend.as_str() {
         "echo" => {
             tracing::info!("using echo provider (no LLM calls)");
-            Arc::new(harness_core::provider::EchoProvider)
+            Arc::new(harness_core::provider::EchoProvider::new())
         }
         "claude-code" | "cc" => {
             let model = &config.provider.model;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod agent;

--- a/crates/cli/tests/echo_integration.rs
+++ b/crates/cli/tests/echo_integration.rs
@@ -1,0 +1,262 @@
+//! Integration tests exercising the full agent loop with the echo provider.
+//!
+//! These tests verify that `anvil run --provider echo` works end-to-end:
+//! plain text echo, scripted tool calls, memory persistence, and session
+//! continuity — all without any real LLM API calls.
+
+use std::sync::Arc;
+
+use harness_cli::agent::{Agent, RunOptions};
+use harness_core::{
+    provider::{EchoProvider, ScriptedToolCall},
+    session::SessionStatus,
+};
+use harness_memory::MemoryDb;
+
+fn make_config(max_iterations: usize) -> harness_core::config::Config {
+    let mut cfg = harness_core::config::Config::default();
+    cfg.agent.max_iterations = max_iterations;
+    cfg.agent.system_prompt = None;
+    cfg
+}
+
+async fn make_memory() -> Arc<MemoryDb> {
+    Arc::new(MemoryDb::in_memory().await.unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic echo: goal in -> deterministic echo response out
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn echo_provider_completes_full_agent_loop() {
+    let provider = Arc::new(EchoProvider::new());
+    let memory = make_memory().await;
+    let config = make_config(10);
+
+    let agent = Agent::new(provider, memory, config);
+    let session = agent.run("test task").await.unwrap();
+
+    assert_eq!(session.status, SessionStatus::Done);
+    assert_eq!(session.iteration, 1);
+
+    let last = session.messages.last().unwrap();
+    assert_eq!(last.text(), Some("echo: test task"));
+}
+
+#[tokio::test]
+async fn echo_provider_handles_empty_goal() {
+    let provider = Arc::new(EchoProvider::new());
+    let memory = make_memory().await;
+    let config = make_config(5);
+
+    let agent = Agent::new(provider, memory, config);
+    let session = agent.run("").await.unwrap();
+
+    assert_eq!(session.status, SessionStatus::Done);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Tool use: scripted tool call -> tool dispatch -> echo final response
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn echo_provider_with_tool_call_exercises_full_loop() {
+    let provider = Arc::new(EchoProvider::scripted(vec![ScriptedToolCall {
+        id: "tool-1".to_string(),
+        name: "echo".to_string(),
+        input: serde_json::json!({"message": "tool-ping"}),
+    }]));
+    let memory = make_memory().await;
+    let config = make_config(10);
+
+    let agent = Agent::new(provider, memory, config);
+    let session = agent.run("exercise tools").await.unwrap();
+
+    assert_eq!(session.status, SessionStatus::Done);
+    // Iteration 1: tool call. Iteration 2: final echo.
+    assert_eq!(session.iteration, 2);
+
+    let last = session.messages.last().unwrap();
+    // After the tool result, echo provider echoes the last user message
+    // (the tool result block), which has no plain text — falls back to "(empty)".
+    assert!(last.text().is_some());
+}
+
+#[tokio::test]
+async fn echo_provider_multiple_tool_calls_in_sequence() {
+    let provider = Arc::new(EchoProvider::scripted(vec![
+        ScriptedToolCall {
+            id: "c1".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "first"}),
+        },
+        ScriptedToolCall {
+            id: "c2".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "second"}),
+        },
+    ]));
+    let memory = make_memory().await;
+    let config = make_config(10);
+
+    let agent = Agent::new(provider, memory, config);
+    let session = agent.run("multi-tool test").await.unwrap();
+
+    assert_eq!(session.status, SessionStatus::Done);
+    // 2 scripted tool calls + 1 final echo = 3 iterations.
+    assert_eq!(session.iteration, 3);
+}
+
+#[tokio::test]
+async fn tool_call_respects_max_iterations() {
+    // Script has 5 tool calls but max_iterations is 2.
+    let provider = Arc::new(EchoProvider::scripted(vec![
+        ScriptedToolCall {
+            id: "c1".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "a"}),
+        },
+        ScriptedToolCall {
+            id: "c2".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "b"}),
+        },
+        ScriptedToolCall {
+            id: "c3".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "c"}),
+        },
+    ]));
+    let memory = make_memory().await;
+    let config = make_config(2);
+
+    let agent = Agent::new(provider, memory, config);
+    let session = agent.run("should cap").await.unwrap();
+
+    assert_eq!(session.status, SessionStatus::Done);
+    assert_eq!(session.iteration, 2);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Memory: episodes are persisted and recallable
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn echo_sessions_persist_to_memory() {
+    let memory = make_memory().await;
+    let provider = Arc::new(EchoProvider::new());
+    let config = make_config(5);
+
+    let agent = Agent::new(provider, Arc::clone(&memory), config);
+    let session = agent.run("remember this").await.unwrap();
+
+    let episodes = memory.recent(session.id, 10).await.unwrap();
+    assert!(
+        episodes.len() >= 2,
+        "expected at least user + assistant episodes, got {}",
+        episodes.len()
+    );
+
+    let roles: Vec<&str> = episodes.iter().map(|e| e.role.as_str()).collect();
+    assert!(roles.contains(&"user"));
+    assert!(roles.contains(&"assistant"));
+}
+
+#[tokio::test]
+async fn echo_tool_session_persists_all_turns() {
+    let memory = make_memory().await;
+    let provider = Arc::new(EchoProvider::scripted(vec![ScriptedToolCall {
+        id: "t1".to_string(),
+        name: "echo".to_string(),
+        input: serde_json::json!({"message": "ping"}),
+    }]));
+    let config = make_config(10);
+
+    let agent = Agent::new(provider, Arc::clone(&memory), config);
+    let session = agent.run("tool + memory").await.unwrap();
+
+    let episodes = memory.recent(session.id, 20).await.unwrap();
+    // At minimum: user goal, assistant tool call, tool result, assistant final.
+    assert!(
+        episodes.len() >= 2,
+        "expected multiple episodes for tool session, got {}",
+        episodes.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Session continuity via named sessions
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn named_session_allows_multi_turn_continuity() {
+    let memory = make_memory().await;
+    let config = make_config(5);
+
+    // Turn 1: initial goal.
+    let provider1 = Arc::new(EchoProvider::new());
+    let agent1 = Agent::new(provider1, Arc::clone(&memory), config.clone());
+    let opts1 = RunOptions {
+        session_name: Some("my-session".to_string()),
+        ..Default::default()
+    };
+    let s1 = agent1.run_with_options("first turn", opts1).await.unwrap();
+    assert_eq!(s1.status, SessionStatus::Done);
+
+    // Turn 2: continue under the same session name.
+    let provider2 = Arc::new(EchoProvider::new());
+    let agent2 = Agent::new(provider2, Arc::clone(&memory), config);
+    let opts2 = RunOptions {
+        session_name: Some("my-session".to_string()),
+        ..Default::default()
+    };
+    let s2 = agent2.run_with_options("second turn", opts2).await.unwrap();
+    assert_eq!(s2.status, SessionStatus::Done);
+
+    // Both sessions completed and persisted episodes under the same name.
+    // The second session injected history from the first (verified by the
+    // echo response reflecting the prior context). We confirm memory has
+    // episodes from both sessions.
+    let all_episodes = memory.recent_by_name("my-session", 20).await.unwrap();
+    assert!(
+        all_episodes.len() >= 4,
+        "expected episodes from both sessions (>= 4), got {}",
+        all_episodes.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. RunOptions override
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn run_options_overrides_config_max_iterations() {
+    let provider = Arc::new(EchoProvider::scripted(vec![
+        ScriptedToolCall {
+            id: "c1".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "x"}),
+        },
+        ScriptedToolCall {
+            id: "c2".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "y"}),
+        },
+        ScriptedToolCall {
+            id: "c3".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "z"}),
+        },
+    ]));
+    let memory = make_memory().await;
+    let config = make_config(10); // Config says 10, options say 1.
+
+    let agent = Agent::new(provider, memory, config);
+    let opts = RunOptions {
+        max_iterations: Some(1),
+        ..Default::default()
+    };
+    let session = agent.run_with_options("override test", opts).await.unwrap();
+    assert_eq!(session.iteration, 1);
+}

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,11 +1,13 @@
 use crate::{
     error::Result,
-    message::{Message, TurnResponse},
+    message::{ContentBlock, Message, MessageContent, Role, StopReason, TurnResponse, Usage},
 };
 use async_trait::async_trait;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::Mutex;
 
 /// Lightweight tool definition passed to providers alongside messages.
 /// Mirrors the JSON schema shape expected by Claude / OpenAI tool-calling APIs.
@@ -65,8 +67,50 @@ pub trait Provider: Send + Sync + 'static {
     }
 }
 
+/// A scripted tool call for deterministic testing.
+#[derive(Debug, Clone)]
+pub struct ScriptedToolCall {
+    pub id: String,
+    pub name: String,
+    pub input: serde_json::Value,
+}
+
 /// Stub provider for tests — echoes input back.
-pub struct EchoProvider;
+///
+/// In its default mode, `EchoProvider` prefixes the last user message with
+/// `"echo: "` and returns `StopReason::EndTurn`.
+///
+/// In **scripted mode** (via [`EchoProvider::scripted`]), it dequeues
+/// pre-loaded tool calls one per turn, returning `StopReason::ToolUse`.
+/// Once the script is exhausted it falls back to the normal echo behaviour.
+/// This allows deterministic end-to-end testing of the full agent loop
+/// including tool dispatch — no real LLM required.
+pub struct EchoProvider {
+    script: Mutex<VecDeque<ScriptedToolCall>>,
+}
+
+impl EchoProvider {
+    /// Plain echo provider — no tool calls, just mirrors input.
+    pub fn new() -> Self {
+        Self {
+            script: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Scripted echo provider — emits pre-loaded tool calls in order,
+    /// then falls back to normal echo behaviour.
+    pub fn scripted(calls: Vec<ScriptedToolCall>) -> Self {
+        Self {
+            script: Mutex::new(VecDeque::from(calls)),
+        }
+    }
+}
+
+impl Default for EchoProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl Provider for EchoProvider {
@@ -75,7 +119,27 @@ impl Provider for EchoProvider {
     }
 
     async fn complete(&self, messages: &[Message]) -> Result<TurnResponse> {
-        use crate::message::{MessageContent, Role, StopReason, Usage};
+        // Check for a scripted tool call first.
+        {
+            let mut script = self.script.lock().unwrap();
+            if let Some(call) = script.pop_front() {
+                return Ok(TurnResponse {
+                    message: Message {
+                        role: Role::Assistant,
+                        content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                            id: call.id,
+                            name: call.name,
+                            input: call.input,
+                        }]),
+                    },
+                    stop_reason: StopReason::ToolUse,
+                    usage: Usage::default(),
+                    model: "echo".to_string(),
+                });
+            }
+        }
+
+        // Default: echo the last user message.
         let last = messages
             .last()
             .and_then(|m| m.text())
@@ -100,10 +164,73 @@ mod tests {
 
     #[tokio::test]
     async fn echo_provider_round_trips() {
-        let p = EchoProvider;
+        let p = EchoProvider::new();
         let msgs = vec![Message::user("hello")];
         let resp = p.complete(&msgs).await.unwrap();
         assert_eq!(resp.message.text(), Some("echo: hello"));
         assert_eq!(resp.model, "echo");
+    }
+
+    #[tokio::test]
+    async fn echo_provider_default_is_plain() {
+        let p = EchoProvider::default();
+        let msgs = vec![Message::user("test")];
+        let resp = p.complete(&msgs).await.unwrap();
+        assert_eq!(resp.stop_reason, StopReason::EndTurn);
+        assert_eq!(resp.message.text(), Some("echo: test"));
+    }
+
+    #[tokio::test]
+    async fn scripted_echo_emits_tool_call_then_echoes() {
+        let p = EchoProvider::scripted(vec![ScriptedToolCall {
+            id: "call-1".to_string(),
+            name: "echo".to_string(),
+            input: serde_json::json!({"message": "ping"}),
+        }]);
+
+        // First call returns the scripted tool use.
+        let msgs = vec![Message::user("goal")];
+        let r1 = p.complete(&msgs).await.unwrap();
+        assert_eq!(r1.stop_reason, StopReason::ToolUse);
+        match &r1.message.content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolUse { name, .. } => assert_eq!(name, "echo"),
+                other => panic!("expected ToolUse, got {other:?}"),
+            },
+            other => panic!("expected Blocks, got {other:?}"),
+        }
+
+        // Second call falls back to echo.
+        let r2 = p.complete(&msgs).await.unwrap();
+        assert_eq!(r2.stop_reason, StopReason::EndTurn);
+        assert_eq!(r2.message.text(), Some("echo: goal"));
+    }
+
+    #[tokio::test]
+    async fn scripted_echo_drains_multiple_calls() {
+        let p = EchoProvider::scripted(vec![
+            ScriptedToolCall {
+                id: "c1".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "a.txt"}),
+            },
+            ScriptedToolCall {
+                id: "c2".to_string(),
+                name: "bash_exec".to_string(),
+                input: serde_json::json!({"command": "ls"}),
+            },
+        ]);
+
+        let msgs = vec![Message::user("do things")];
+
+        let r1 = p.complete(&msgs).await.unwrap();
+        assert_eq!(r1.stop_reason, StopReason::ToolUse);
+
+        let r2 = p.complete(&msgs).await.unwrap();
+        assert_eq!(r2.stop_reason, StopReason::ToolUse);
+
+        // Script exhausted — falls back to echo.
+        let r3 = p.complete(&msgs).await.unwrap();
+        assert_eq!(r3.stop_reason, StopReason::EndTurn);
     }
 }


### PR DESCRIPTION
## Thinking Path

1. Anvil project: Rust agent harness with provider-agnostic LLM trait
2. `crates/core/src/provider.rs`: EchoProvider exists as a simple text echo stub
3. `crates/cli/src/agent.rs`: Agent loop handles tool calls, memory, sessions
4. Problem: EchoProvider only returns text — cannot exercise tool-call path in tests
5. Solution: Add `EchoProvider::scripted()` to queue deterministic tool calls
6. Need integration test access: add `lib.rs` to CLI crate, expose agent module
7. Write integration tests in `crates/cli/tests/echo_integration.rs`
8. Update README with echo provider testing documentation

## What Changed

- **`crates/core/src/provider.rs`**: EchoProvider changed from unit struct to struct with `Mutex<VecDeque<ScriptedToolCall>>` field. Added `new()`, `scripted()`, and `Default` impl. When scripted calls remain, `complete()` dequeues and returns `ToolUse`; otherwise echoes normally. Added 4 unit tests for the new scripted behaviour.
- **`crates/cli/Cargo.toml`**: Added `[lib]` section for `harness_cli` library target.
- **`crates/cli/src/lib.rs`**: New file exposing `pub mod agent` for integration tests.
- **`crates/cli/src/commands/run.rs`** and **`eval.rs`**: Updated `EchoProvider` → `EchoProvider::new()` (no longer a unit struct).
- **`crates/cli/tests/echo_integration.rs`**: 9 integration tests covering: plain echo loop, empty goal, scripted tool dispatch, multi-tool sequences, max-iteration cap, memory persistence, tool+memory sessions, named-session continuity, and RunOptions override.
- **`README.md`**: Added "Testing with the echo provider" section with CLI usage and Rust API examples.

## Verification

```bash
cargo test --workspace            # All tests pass (96 total, 0 failures)
cargo clippy --workspace --all-targets -- -D warnings  # Zero warnings
cargo fmt --all -- --check        # Clean
```

Specifically:
```bash
cargo test -p harness-cli --test echo_integration  # 9/9 pass
cargo test -p harness-core                          # 14/14 pass (includes 4 new echo tests)
```

## Risks

Low risk. Changes are additive:
- EchoProvider gains a new constructor; existing `EchoProvider::new()` is behaviourally identical to the former unit struct
- No changes to the core agent loop or production provider code
- `lib.rs` re-exports only the `agent` module; `commands` and `ui` remain private

Closes [ANGA-576](/ANGA/issues/ANGA-576)
Parent: [ANGA-553](/ANGA/issues/ANGA-553)