### PR TITLE
feat(cli): contextual fallback hints on provider failure

### DIFF
--- a/crates/cli/src/commands/eval.rs
+++ b/crates/cli/src/commands/eval.rs
@@ -67,7 +67,11 @@ pub async fn execute(args: EvalArgs) -> anyhow::Result<()> {
         }
         _ => {
             let api_key = config.resolved_api_key().ok_or_else(|| {
-                anyhow::anyhow!("ANTHROPIC_API_KEY not set — pass via env or config")
+                let base = "ANTHROPIC_API_KEY not set — pass via env or config";
+                match super::provider_fallback_hint(&backend) {
+                    Some(hint) => anyhow::anyhow!("{base}\n{hint}"),
+                    None => anyhow::anyhow!("{base}"),
+                }
             })?;
             Arc::new(ClaudeProvider::new(
                 api_key,
@@ -98,7 +102,12 @@ pub async fn execute(args: EvalArgs) -> anyhow::Result<()> {
             .unwrap_or_else(|| format!("case {}", idx + 1));
 
         let agent = Agent::new(Arc::clone(&provider), Arc::clone(&memory), config.clone());
-        let session = agent.run(&case.goal).await?;
+        let session = agent.run(&case.goal).await.map_err(|e| {
+            match super::provider_fallback_hint(&backend) {
+                Some(hint) => anyhow::anyhow!("{e}\n{hint}"),
+                None => anyhow::anyhow!("{e}"),
+            }
+        })?;
 
         let response = session
             .messages

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3,3 +3,50 @@ pub mod config;
 pub mod eval;
 pub mod memory;
 pub mod run;
+
+/// Return a contextual fallback suggestion when a provider fails.
+///
+/// The hint tells the user which alternative provider or env var to try,
+/// based on which backend just failed.
+pub(crate) fn provider_fallback_hint(backend: &str) -> Option<&'static str> {
+    match backend {
+        "claude-code" | "cc" => Some(
+            "Hint: Try --provider claude with ANTHROPIC_API_KEY set",
+        ),
+        "echo" => None, // echo never needs a fallback
+        // "claude" or any direct-API backend
+        _ => Some(
+            "Hint: Set ANTHROPIC_API_KEY or try --provider echo for testing",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_hint_cc_suggests_claude() {
+        let hint = provider_fallback_hint("cc").unwrap();
+        assert!(hint.contains("--provider claude"));
+        assert!(hint.contains("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn fallback_hint_claude_code_suggests_claude() {
+        let hint = provider_fallback_hint("claude-code").unwrap();
+        assert!(hint.contains("--provider claude"));
+    }
+
+    #[test]
+    fn fallback_hint_claude_suggests_api_key_or_echo() {
+        let hint = provider_fallback_hint("claude").unwrap();
+        assert!(hint.contains("ANTHROPIC_API_KEY"));
+        assert!(hint.contains("--provider echo"));
+    }
+
+    #[test]
+    fn fallback_hint_echo_returns_none() {
+        assert!(provider_fallback_hint("echo").is_none());
+    }
+}

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -121,7 +121,10 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         }
         _ => Arc::new(
             ClaudeProvider::from_env(&config.provider.model, config.provider.max_tokens)
-                .map_err(|e| anyhow::anyhow!("{}", e))?,
+                .map_err(|e| match super::provider_fallback_hint(&backend) {
+                    Some(hint) => anyhow::anyhow!("{e}\n{hint}"),
+                    None => anyhow::anyhow!("{e}"),
+                })?,
         ),
     };
 
@@ -143,7 +146,12 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         ui::print_session_header("stream", &config.provider.model, &backend);
 
         println!("\n{}", "-".repeat(60));
-        let mut token_stream = provider.stream(&msgs).await?;
+        let mut token_stream = provider.stream(&msgs).await.map_err(|e| {
+            match super::provider_fallback_hint(&backend) {
+                Some(hint) => anyhow::anyhow!("{e}\n{hint}"),
+                None => anyhow::anyhow!("{e}"),
+            }
+        })?;
         let mut full_text = String::new();
         let stdout = std::io::stdout();
         let mut out = stdout.lock();
@@ -192,7 +200,12 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         };
 
         let t0 = Instant::now();
-        let session = agent.run_with_options(&args.goal, opts).await?;
+        let session = agent.run_with_options(&args.goal, opts).await.map_err(|e| {
+            match super::provider_fallback_hint(&backend) {
+                Some(hint) => anyhow::anyhow!("{e}\n{hint}"),
+                None => anyhow::anyhow!("{e}"),
+            }
+        })?;
         let elapsed_ms = t0.elapsed().as_millis() as u64;
 
         if let Some(msg) = session.messages.last() {


### PR DESCRIPTION
## Thinking Path

1. Anvil project → CLI binary (`crates/cli`)
2. Provider selection in `run.rs` and `eval.rs` commands
3. Error handling path when provider fails (creation or runtime)
4. `HarnessError` variants: `Provider`, `Config`, `Api`
5. User sees raw error with no guidance on what to try next
6. Need: contextual hint appended to error message based on which backend failed
7. Solution: `provider_fallback_hint()` function in `commands/mod.rs`, applied at error boundaries

## What Changed

- Added `provider_fallback_hint(backend)` in `crates/cli/src/commands/mod.rs` — returns a contextual suggestion string based on the failing provider
- `run.rs`: wrapped provider creation error, streaming error, and agent run error with fallback hints
- `eval.rs`: wrapped provider creation error and agent run error with fallback hints
- Added 4 unit tests covering cc, claude-code, claude, and echo hint behavior

## Verification

- `cargo test --workspace` — all tests pass (14 CLI tests including 4 new)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — applied
- Manual verification: when `cc` fails → "Hint: Try --provider claude with ANTHROPIC_API_KEY set"
- Manual verification: when `claude` fails → "Hint: Set ANTHROPIC_API_KEY or try --provider echo for testing"
- Echo provider returns no hint (no fallback needed)

## Risks

Low risk — only appends text to existing error messages. No behavioral changes to success paths. No new dependencies.

## Checklist

- [x] `cargo test` passes locally
- [x] `cargo clippy -- -D warnings` is clean
- [x] `cargo fmt` has been run
- [x] New behaviour has a test (using `EchoProvider` where possible)
- [x] Commit messages follow Conventional Commits
- [x] The PR description explains *why*, not just *what*

Closes ANGA-577