### PR TITLE
docs: autonomous merge policy, add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Thinking Path
+<!-- Trace from the top of the project down to this change (5–8 steps minimum). -->
+
+## What Changed
+<!-- Bullet list of concrete changes, one per logical unit. -->
+
+## Verification
+<!-- How a reviewer can confirm it works (test commands, manual steps). -->
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` clean
+- [ ] `cargo fmt --check` clean
+
+## Risks
+<!-- Explicit risk acknowledgment: race conditions, migrations, behavioral shifts, or "Low risk" with justification. -->
+
+## Checklist
+- [ ] Tests pass locally
+- [ ] No new warnings from clippy
+- [ ] Code is formatted with `cargo fmt`
+- [ ] Commit messages follow conventional format
+- [ ] Co-Authored-By trailer included for agent commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Scopes: `core`, `tools`, `memory`, `cli`, `gateway`, `tui`, `paperclip`, `github
 ## Branching model
 
 ```
-main              ← stable, protected — PRs from dev only, requires human approval
+main              ← stable, protected — PRs from dev only, merged autonomously when CI is green and review passes
   dev             ← integration — PRs from feature/* only (no direct commits)
     feature/*     ← new features
     fix/*         ← bug fixes
@@ -71,7 +71,7 @@ main              ← stable, protected — PRs from dev only, requires human ap
     chore/*       ← deps / CI / tooling
 ```
 
-All feature branches cut from `dev`. Open a PR to `dev`; `dev` → `main` requires board approval.
+All feature branches cut from `dev`. Open a PR to `dev`; `dev` → `main` merges happen autonomously when all CI gates pass and review is complete.
 Squash-merge preferred for feature/* and fix/*; merge commit for larger milestones.
 
 ## Testing philosophy


### PR DESCRIPTION
## Summary
- Updated CONTRIBUTING.md to remove board/human approval requirement for dev→main merges
- Added .github/PULL_REQUEST_TEMPLATE.md with Rust-oriented review checklist
- Agents now merge autonomously when all CI gates pass

Closes ANGA-589

🤖 Generated with [Claude Code](https://claude.com/claude-code)