### PR TITLE
fix(cli): restore paperclip subcommand in anvil (ANGA-795)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "harness-core",
  "harness-evolution",
  "harness-memory",
+ "harness-paperclip",
  "harness-tools",
  "indicatif",
  "serde",

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ export PAPERCLIP_API_KEY=...
 export PAPERCLIP_API_URL=http://localhost:3100
 anvil paperclip --agent-id <your-agent-id> --company-id <company-id>
 
+# Dogfood artifact freshness check (use before sharing target/debug binaries)
+cargo build -p harness-cli
+./target/debug/anvil --help | grep paperclip
+./target/debug/anvil paperclip --help
+
 # Search episodic memory
 anvil memory search "recent goals"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ evolution = ["dep:harness-evolution"]
 harness-core = { workspace = true }
 harness-tools = { workspace = true }
 harness-memory = { workspace = true }
+harness-paperclip = { workspace = true }
 harness-evolution = { path = "../evolution", optional = true }
 tokio = { workspace = true }
 futures = { workspace = true }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod config;
 pub mod eval;
 pub mod memory;
+pub mod paperclip;
 pub mod run;

--- a/crates/cli/src/commands/paperclip.rs
+++ b/crates/cli/src/commands/paperclip.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use clap::{Parser, Subcommand};
+use clap::{Args, Subcommand};
 use tracing::info;
 
 use harness_core::{
@@ -39,7 +39,7 @@ use crate::agent::Agent;
 // ── CLI args ───────────────────────────────────────────────────────────────────
 
 /// Paperclip control-plane integration (heartbeat, whoami)
-#[derive(Parser)]
+#[derive(Args)]
 pub struct PaperclipArgs {
     /// Paperclip API base URL
     #[arg(
@@ -77,7 +77,7 @@ enum PaperclipCommand {
     Heartbeat(HeartbeatCmd),
 }
 
-#[derive(Parser)]
+#[derive(Args)]
 struct HeartbeatCmd {
     /// Maximum tasks to process in this heartbeat
     #[arg(long, default_value = "1")]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,6 +29,8 @@ enum Commands {
     Eval(commands::eval::EvalArgs),
     /// Manage authentication credentials
     Auth(commands::auth::AuthArgs),
+    /// Paperclip control-plane integration (heartbeat, whoami)
+    Paperclip(commands::paperclip::PaperclipArgs),
 }
 
 #[tokio::main]
@@ -48,5 +50,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Memory(args) => commands::memory::execute(args).await,
         Commands::Eval(args) => commands::eval::execute(args).await,
         Commands::Auth(args) => commands::auth::execute(args).await,
+        Commands::Paperclip(args) => commands::paperclip::execute(args).await,
     }
 }

--- a/crates/cli/tests/cli_surface.rs
+++ b/crates/cli/tests/cli_surface.rs
@@ -1,0 +1,39 @@
+//! CLI surface regression tests.
+//!
+//! These tests ensure built artifacts expose expected top-level subcommands,
+//! so dogfood workflows do not depend on stale binaries.
+
+use std::process::Command;
+
+fn run_anvil(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_anvil"))
+        .args(args)
+        .output()
+        .expect("failed to run anvil binary")
+}
+
+#[test]
+fn top_level_help_lists_paperclip_subcommand() {
+    let output = run_anvil(&["--help"]);
+    assert!(
+        output.status.success(),
+        "anvil --help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("paperclip"),
+        "expected `paperclip` in anvil --help output, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn paperclip_subcommand_help_is_available() {
+    let output = run_anvil(&["paperclip", "--help"]);
+    assert!(
+        output.status.success(),
+        "anvil paperclip --help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- restore `anvil paperclip` by wiring `Paperclip` into the top-level CLI command enum and dispatcher
- export `commands::paperclip` and add `harness-paperclip` as a CLI dependency so the command module compiles
- add CLI surface regression tests to ensure `anvil --help` lists `paperclip` and `anvil paperclip --help` remains valid
- document a local dogfood artifact freshness check in `README.md`

## Verification
- `cargo check -p harness-cli`
- `cargo check -p harness-cli --tests`
- `cargo clippy -p harness-cli --all-targets -- -D warnings`
- `cargo test -p harness-cli` *(fails in this runtime because linker `cc` is unavailable; compile/check paths pass)*

## Issue
- ANGA-795