### PR TITLE
fix(test): stabilize Windows workspace gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -607,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -919,6 +919,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness-gateway"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "chrono",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "tower-http 0.5.2",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "harness-github"
 version = "0.1.0"
 dependencies = [
@@ -1002,7 +1021,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1640,7 +1659,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2110,7 +2129,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2716,7 +2735,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2871,6 +2890,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
@@ -2880,7 +2911,7 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -3067,6 +3098,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/crates/core/src/providers/claude_code.rs
+++ b/crates/core/src/providers/claude_code.rs
@@ -20,7 +20,11 @@ pub struct ClaudeCodeProvider {
 /// Returns a hint suggesting the `claude` provider as a fallback, but only when
 /// `ANTHROPIC_API_KEY` is not already set in the environment.
 fn fallback_hint() -> String {
-    if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+    fallback_hint_for_api_key(std::env::var("ANTHROPIC_API_KEY").ok())
+}
+
+fn fallback_hint_for_api_key(api_key: Option<String>) -> String {
+    if api_key.is_some() {
         String::new()
     } else {
         "\nTip: try --provider claude with ANTHROPIC_API_KEY set".to_string()
@@ -305,18 +309,14 @@ mod tests {
 
     #[test]
     fn fallback_hint_shown_when_api_key_unset() {
-        // Ensure the key is not set for this test.
-        std::env::remove_var("ANTHROPIC_API_KEY");
-        let hint = fallback_hint();
+        let hint = fallback_hint_for_api_key(None);
         assert!(hint.contains("--provider claude"));
         assert!(hint.contains("ANTHROPIC_API_KEY"));
     }
 
     #[test]
     fn fallback_hint_hidden_when_api_key_set() {
-        std::env::set_var("ANTHROPIC_API_KEY", "sk-test-key");
-        let hint = fallback_hint();
+        let hint = fallback_hint_for_api_key(Some("sk-test-key".to_string()));
         assert!(hint.is_empty());
-        std::env::remove_var("ANTHROPIC_API_KEY");
     }
 }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -150,8 +150,13 @@ impl ToolHandler for BashExecTool {
         let output = tokio::time::timeout(
             Duration::from_secs(30),
             tokio::task::spawn_blocking(move || {
-                std::process::Command::new("sh")
-                    .arg("-c")
+                let (shell, flag) = if cfg!(windows) {
+                    ("cmd", "/C")
+                } else {
+                    ("sh", "-c")
+                };
+                std::process::Command::new(shell)
+                    .arg(flag)
                     .arg(&command)
                     .output()
             }),
@@ -284,9 +289,8 @@ mod tests {
     #[tokio::test]
     async fn bash_exec_nonzero_exit_is_error() {
         let tool = BashExecTool;
-        // ls on a non-existent path exits non-zero; ls is in the allowlist
         let out = tool
-            .call(json!({"command": "ls /this_path_does_not_exist_xyz_12345"}))
+            .call(json!({"command": "cargo --definitely-not-a-real-cargo-flag"}))
             .await;
         assert!(out.is_error, "expected error for non-zero exit");
     }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -653,6 +653,7 @@ mod skill_tests {
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         let dir =
             std::env::temp_dir().join(format!("anvil_skill_test_{}_{}", id, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::env::set_var("ANVIL_SKILLS_DIR", &dir);
         (dir, guard)


### PR DESCRIPTION
Closes ANGA-354

## Thinking Path
1. ANGA-353 could not be pushed because the repository pre-push hook runs `cargo test --workspace`.
2. The default workspace test run failed in existing env-mutating `harness-core` tests and Windows shell-spawn assumptions in `harness-tools`.
3. The core fallback-hint tests only needed to validate conditional hint rendering, so they now exercise a pure helper instead of mutating `ANTHROPIC_API_KEY`.
4. The production `fallback_hint()` path still reads `ANTHROPIC_API_KEY` exactly once and delegates to that helper.
5. `BashExecTool` already validates the allowlisted first token before spawning a shell, so using the platform shell preserves that allowlist while making Windows execution possible.
6. The nonzero-exit test now uses an invalid `cargo` flag instead of Unix-only `ls` behavior.
7. The skill-tool test helper now clears its own generated temp directory before setting `ANVIL_SKILLS_DIR`, preventing stale files from recycled Windows temp paths from changing list counts.
8. `Cargo.lock` was refreshed because `cargo test --workspace` includes the existing gateway workspace crate that was missing from the lockfile, and `rustls-webpki` was bumped to the patched lockfile version required by the CI audit gate.

## What Changed
- Added a pure `fallback_hint_for_api_key` helper so fallback-hint tests no longer mutate process env vars.
- Switched `BashExecTool` shell spawning to `cmd /C` on Windows and `sh -c` elsewhere.
- Updated the nonzero BashExecTool test to use a cross-platform allowlisted command.
- Cleared generated skill-test temp directories before reuse to keep default-parallel Windows test runs deterministic.
- Refreshed `Cargo.lock` for the existing workspace gateway dependency set and updated `rustls-webpki` to `0.103.12` for the CI security audit.

## Verification
- `cargo fmt --check` PASS
- `cargo test -p harness-core --lib` PASS
- `cargo test -p harness-tools --lib` PASS
- `cargo test --workspace` PASS
- `cargo clippy --workspace -- -D warnings` PASS
- `cargo audit --ignore RUSTSEC-2023-0071` PASS with existing allowed warnings
- Pre-push hook PASS (`cargo test --workspace`)

## Risks
Low risk. The env-test and skill-temp changes are test-only. The shell change affects BashExecTool execution on Windows, but retains the existing first-token allowlist before shell invocation and keeps Unix behavior unchanged. The lockfile audit update is a patch-level transitive dependency update.

## Checklist
- [x] Scope is limited to ANGA-354
- [x] Tests pass locally
- [x] Clippy passes locally
- [x] Code is formatted with `cargo fmt`
- [x] Commit includes required Paperclip co-author footer
- [x] No protected branch direct push