### PR TITLE
feat(evolution): APT-pattern safety gates with auto-rollback (ANGA-900)

### DIFF
--- a/crates/evolution/SAFETY_GATES.md
+++ b/crates/evolution/SAFETY_GATES.md
@@ -1,0 +1,178 @@
+# Evolution Safety Gates (APT Pattern)
+
+This document describes the APT (Agentic Prompt Template) pattern safety gates implemented in the self-evolution engine to prevent performance degradation.
+
+## Overview
+
+The `SafeApplier` implements a three-stage safety gate system that wraps around prompt evolution to ensure new prompts don't degrade system performance:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Evolution Pipeline with Safety Gates              │
+├─────────────────────────────────────────────────────┤
+│  Observer → Critic → Generator → Validators (5×)   │
+│                                    ↓                │
+│                          ┌─────────────────┐       │
+│                          │  SafeApplier    │       │
+│                          ├─────────────────┤       │
+│                          │ 1. Pre-hook     │       │
+│                          │    - Backup     │       │
+│                          │    - Baseline   │       │
+│                          ├─────────────────┤       │
+│                          │ 2. Apply        │       │
+│                          │    - Write cfg  │       │
+│                          ├─────────────────┤       │
+│                          │ 3. Post-hook    │       │
+│                          │    - Benchmark  │       │
+│                          │    - Compare    │       │
+│                          │    - Rollback?  │       │
+│                          └─────────────────┘       │
+└─────────────────────────────────────────────────────┘
+```
+
+## Three Safety Gates
+
+### Gate 1: Pre-Hook (Backup)
+
+**Location**: `SafeApplier::backup_current_state()`
+
+**Actions**:
+1. Creates `~/.paperclip/harness/prompt-backups/` directory
+2. Backs up current system prompt to timestamped file
+3. Runs baseline benchmarks to capture current performance
+4. Stores backup metadata (timestamp, candidate ID, baseline score) as JSON
+
+**Files created**:
+- `prompt-YYYYMMDD-HHMMSS.txt` — backed-up prompt
+- `prompt-YYYYMMDD-HHMMSS.meta.json` — backup metadata
+
+### Gate 2: Apply
+
+**Location**: `SafeApplier::apply_prompt()`
+
+**Actions**:
+1. Loads `~/.paperclip/harness/config.toml`
+2. Updates `agent.system_prompt` field
+3. Writes modified config back to disk
+
+**Failure behavior**: If apply fails, post-hook is skipped and error is returned immediately.
+
+### Gate 3: Post-Hook (Benchmark + Auto-Rollback)
+
+**Location**: `SafeApplier::run_benchmarks()` + rollback logic
+
+**Actions**:
+1. Executes `./scripts/run-evolution-benchmarks.sh`
+2. Parses JSON output with benchmark scores
+3. Compares new score to baseline score
+4. **Auto-rollback** if regression > 10%
+
+**Rollback trigger**:
+```rust
+let regression_pct = (baseline_score - new_score) / baseline_score;
+if regression_pct > 0.10 {
+    // Restore prompt from backup
+    // Return error to mark evolution as failed
+}
+```
+
+## Benchmark Format
+
+The benchmark runner script must output JSON to stdout in this format:
+
+```json
+{
+  "score": 0.85,
+  "metrics": {
+    "build_success": 1.0,
+    "test_pass_rate": 0.85,
+    "clippy_clean": 0.9,
+    "fmt_clean": 1.0
+  }
+}
+```
+
+**Score range**: 0.0 (worst) to 1.0 (best)
+
+**Default weights** (in `run-evolution-benchmarks.sh`):
+- Build success: 25%
+- Test pass rate: 35%
+- Clippy clean: 20%
+- Fmt clean: 20%
+
+## Benchmark Runner Script
+
+**Path**: `./scripts/run-evolution-benchmarks.sh`
+
+**Metrics measured**:
+1. **Build success**: Does `cargo build --workspace --all-targets` succeed?
+2. **Test pass rate**: Percentage of tests passing in `cargo test --workspace`
+3. **Clippy clean**: Does `cargo clippy -- -D warnings` pass?
+4. **Fmt clean**: Does `cargo fmt -- --check` pass?
+
+**Fallback behavior**: If the script doesn't exist, SafeApplier returns a perfect score (1.0) and skips validation. This allows the system to function before benchmarks are fully integrated.
+
+## Usage
+
+The `SafeApplier` is automatically used when calling `harness_evolution::defaults::default_engine()`:
+
+```rust
+use harness_evolution::defaults::default_engine;
+use harness_memory::MemoryDb;
+
+let memory = Arc::new(MemoryDb::in_memory().await?);
+let engine = default_engine(Arc::clone(&memory)); // Uses SafeApplier
+let outcome = engine.evolve(&session, &current_prompt).await?;
+```
+
+To bypass safety gates (for testing), use `unsafe_engine()`:
+
+```rust
+use harness_evolution::defaults::unsafe_engine;
+
+let engine = unsafe_engine(Arc::clone(&memory)); // No-op applier
+```
+
+## Backup Management
+
+- **Location**: `~/.paperclip/harness/prompt-backups/`
+- **Retention**: Last 10 backups are kept
+- **Cleanup**: Automatic after successful evolution
+- **Naming**: `prompt-YYYYMMDD-HHMMSS.txt` + `.meta.json`
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Backup creation fails | Error returned, evolution aborted |
+| Apply fails | Error returned, post-hook skipped |
+| Benchmark script missing | Skip validation, accept prompt |
+| Benchmark script fails | Rollback, return error |
+| Regression > 10% | Rollback, return error with details |
+| Rollback fails | Error returned (system may be in inconsistent state) |
+
+## Testing
+
+Unit tests are in `crates/evolution/src/safe_applier.rs`:
+
+- `test_safe_applier_backup_and_rollback`: Verifies backup creation
+- `test_benchmark_parsing`: Validates JSON parsing
+
+Run tests:
+```bash
+cargo test --package harness-evolution
+```
+
+## Configuration
+
+Default values (can be customized via `SafeApplier::with_paths()`):
+
+- **Backup directory**: `~/.paperclip/harness/prompt-backups/`
+- **Benchmark script**: `./scripts/run-evolution-benchmarks.sh`
+- **Regression threshold**: 10% (0.10)
+
+## Related
+
+- **ANGA-900**: Self-Evolution Safety Gates with APT Hooks
+- **ANGA-865**: APT Pattern Brainstorm (parent task)
+- **ANGA-901**: `/review-self` command (APT pattern reference implementation)

--- a/crates/evolution/src/defaults.rs
+++ b/crates/evolution/src/defaults.rs
@@ -232,7 +232,32 @@ impl Applier for DefaultApplier {
 
 /// Construct a fully-wired [`crate::engine::EvolutionEngine`] with all-default
 /// stages and the provided memory store.
+///
+/// **Safety gates enabled**: Uses [`crate::safe_applier::SafeApplier`] which implements:
+/// - Pre-hook: backs up current prompt before applying
+/// - Post-hook: runs benchmarks and compares to baseline
+/// - Auto-rollback: reverts if performance regresses >10%
 pub fn default_engine(memory: Arc<MemoryDb>) -> crate::engine::EvolutionEngine {
+    use std::sync::Arc;
+    crate::engine::EvolutionEngine {
+        observer: Arc::new(DefaultObserver),
+        critic: Arc::new(DefaultCritic),
+        generator: Arc::new(DefaultGenerator),
+        validators: vec![
+            Arc::new(DefaultValidator::new("safety")),
+            Arc::new(DefaultValidator::new("coherence")),
+            Arc::new(DefaultValidator::new("length")),
+            Arc::new(DefaultValidator::new("format")),
+            Arc::new(DefaultValidator::new("relevance")),
+        ],
+        applier: Arc::new(crate::safe_applier::SafeApplier::new()),
+        memory,
+    }
+}
+
+/// Construct an evolution engine with the original no-op applier (for testing).
+#[allow(dead_code)]
+pub fn unsafe_engine(memory: Arc<MemoryDb>) -> crate::engine::EvolutionEngine {
     use std::sync::Arc;
     crate::engine::EvolutionEngine {
         observer: Arc::new(DefaultObserver),

--- a/crates/evolution/src/lib.rs
+++ b/crates/evolution/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod defaults;
 pub mod engine;
+pub mod safe_applier;
 pub mod traits;
 pub mod types;
 
@@ -27,6 +28,7 @@ pub mod types;
 mod tests;
 
 pub use engine::EvolutionEngine;
+pub use safe_applier::SafeApplier;
 pub use types::{
     EvolutionOutcome, EvolutionRecord, PromptCandidate, PromptScore, SessionSummary, ValidationVote,
 };

--- a/crates/evolution/src/safe_applier.rs
+++ b/crates/evolution/src/safe_applier.rs
@@ -1,0 +1,430 @@
+//! SafeApplier – APT-pattern evolution applier with backup, benchmarking, and rollback.
+//!
+//! Implements the Applier trait with three safety gates:
+//! 1. **Pre-hook**: Backs up current prompt before applying
+//! 2. **Apply**: Writes new prompt to config.toml
+//! 3. **Post-hook**: Runs benchmarks and auto-rolls back if performance regresses >10%
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::process::Command;
+use tracing::{debug, info, warn};
+
+use crate::traits::Applier;
+use crate::types::{EvolutionRecord, PromptCandidate};
+
+/// Benchmark result format expected from the benchmark runner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkResult {
+    /// Overall score (0.0 - 1.0, higher is better)
+    pub score: f64,
+    /// Individual metric scores
+    pub metrics: BenchmarkMetrics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkMetrics {
+    pub build_success: f64,
+    pub test_pass_rate: f64,
+    pub clippy_clean: f64,
+    pub fmt_clean: f64,
+}
+
+/// Backup record stored alongside the backed-up prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BackupRecord {
+    timestamp: String,
+    candidate_id: String,
+    candidate_description: String,
+    baseline_score: Option<f64>,
+}
+
+/// Applier that implements APT-pattern safety gates:
+/// - Pre-hook: backup current prompt
+/// - Apply: write new prompt to config
+/// - Post-hook: benchmark + auto-rollback on regression
+pub struct SafeApplier {
+    /// Path to backup directory (default: ~/.paperclip/harness/prompt-backups)
+    backup_dir: PathBuf,
+    /// Path to benchmark runner script
+    benchmark_script: PathBuf,
+    /// Regression threshold (0.10 = 10%)
+    regression_threshold: f64,
+}
+
+impl SafeApplier {
+    /// Create a new SafeApplier with default paths.
+    pub fn new() -> Self {
+        let mut backup_dir = dirs_home().unwrap_or_else(|| PathBuf::from("."));
+        backup_dir.push(".paperclip/harness/prompt-backups");
+
+        let benchmark_script = PathBuf::from("./scripts/run-evolution-benchmarks.sh");
+
+        Self {
+            backup_dir,
+            benchmark_script,
+            regression_threshold: 0.10, // 10%
+        }
+    }
+
+    /// Create with custom paths (for testing).
+    #[allow(dead_code)]
+    pub fn with_paths(backup_dir: PathBuf, benchmark_script: PathBuf) -> Self {
+        Self {
+            backup_dir,
+            benchmark_script,
+            regression_threshold: 0.10,
+        }
+    }
+
+    /// Pre-hook: Back up current prompt and baseline benchmark score.
+    async fn backup_current_state(&self, candidate: &PromptCandidate) -> anyhow::Result<PathBuf> {
+        // Ensure backup directory exists
+        std::fs::create_dir_all(&self.backup_dir)?;
+
+        // Read current config
+        let config = harness_core::config::Config::load()?;
+        let current_prompt = config
+            .agent
+            .system_prompt
+            .unwrap_or_else(|| "You are a helpful assistant.".to_string());
+
+        // Run baseline benchmarks (if script exists)
+        let baseline_score = self.run_benchmarks().await.ok().map(|r| r.score);
+
+        // Create timestamped backup
+        let timestamp = Utc::now().format("%Y%m%d-%H%M%S");
+        let backup_path = self.backup_dir.join(format!("prompt-{}.txt", timestamp));
+
+        // Write backup
+        std::fs::write(&backup_path, current_prompt)?;
+
+        // Write backup metadata
+        let record = BackupRecord {
+            timestamp: timestamp.to_string(),
+            candidate_id: candidate.id.to_string(),
+            candidate_description: candidate.description.clone(),
+            baseline_score,
+        };
+        let record_path = self
+            .backup_dir
+            .join(format!("prompt-{}.meta.json", timestamp));
+        std::fs::write(&record_path, serde_json::to_string_pretty(&record)?)?;
+
+        info!(
+            backup_path = %backup_path.display(),
+            baseline_score = ?baseline_score,
+            "backed up current prompt"
+        );
+
+        Ok(backup_path)
+    }
+
+    /// Apply: Write new prompt to config.toml
+    async fn apply_prompt(&self, candidate: &PromptCandidate) -> anyhow::Result<()> {
+        let config_path = config_path();
+
+        // Load current config
+        let mut config = harness_core::config::Config::load()?;
+
+        // Update system prompt
+        config.agent.system_prompt = Some(candidate.prompt.clone());
+
+        // Write back to disk
+        let toml = toml::to_string_pretty(&config)?;
+        std::fs::write(&config_path, toml)?;
+
+        info!(
+            config_path = %config_path.display(),
+            candidate_id = %candidate.id,
+            "applied new prompt to config"
+        );
+
+        Ok(())
+    }
+
+    /// Post-hook: Run benchmarks and check for regression.
+    async fn run_benchmarks(&self) -> anyhow::Result<BenchmarkResult> {
+        if !self.benchmark_script.exists() {
+            debug!(
+                script = %self.benchmark_script.display(),
+                "benchmark script not found, skipping benchmark validation"
+            );
+            // Return perfect score when benchmarks are not available
+            return Ok(BenchmarkResult {
+                score: 1.0,
+                metrics: BenchmarkMetrics {
+                    build_success: 1.0,
+                    test_pass_rate: 1.0,
+                    clippy_clean: 1.0,
+                    fmt_clean: 1.0,
+                },
+            });
+        }
+
+        info!(script = %self.benchmark_script.display(), "running benchmarks");
+
+        let output = Command::new(&self.benchmark_script)
+            .output()
+            .map_err(|e| anyhow::anyhow!("failed to run benchmark script: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("benchmark script failed: {}", stderr);
+        }
+
+        // Parse benchmark-results.json
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let result: BenchmarkResult = serde_json::from_str(&stdout)
+            .map_err(|e| anyhow::anyhow!("failed to parse benchmark results: {}", e))?;
+
+        info!(score = result.score, "benchmark completed");
+        Ok(result)
+    }
+
+    /// Rollback: Restore prompt from backup.
+    async fn rollback(&self, backup_path: &PathBuf) -> anyhow::Result<()> {
+        warn!(backup = %backup_path.display(), "rolling back to previous prompt");
+
+        // Read backup
+        let backup_prompt = std::fs::read_to_string(backup_path)?;
+
+        // Load config
+        let config_path = config_path();
+        let mut config = harness_core::config::Config::load()?;
+
+        // Restore old prompt
+        config.agent.system_prompt = Some(backup_prompt);
+
+        // Write back
+        let toml = toml::to_string_pretty(&config)?;
+        std::fs::write(&config_path, toml)?;
+
+        info!("rollback complete");
+        Ok(())
+    }
+
+    /// Clean up old backups (keep last 10).
+    async fn cleanup_old_backups(&self) -> anyhow::Result<()> {
+        if !self.backup_dir.exists() {
+            return Ok(());
+        }
+
+        let mut backups: Vec<_> = std::fs::read_dir(&self.backup_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "txt")
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        // Sort by modification time (oldest first)
+        backups.sort_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()));
+
+        // Keep last 10, delete the rest
+        if backups.len() > 10 {
+            for entry in &backups[..backups.len() - 10] {
+                let path = entry.path();
+                std::fs::remove_file(&path)?;
+                // Also remove metadata file
+                if let Some(stem) = path.file_stem() {
+                    let meta_path = self
+                        .backup_dir
+                        .join(format!("{}.meta.json", stem.to_string_lossy()));
+                    let _ = std::fs::remove_file(meta_path);
+                }
+                debug!(path = %path.display(), "removed old backup");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for SafeApplier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Applier for SafeApplier {
+    async fn apply(
+        &self,
+        candidate: &PromptCandidate,
+        _record: &EvolutionRecord,
+    ) -> anyhow::Result<()> {
+        // Gate 1: Pre-hook — backup current state
+        let backup_path = self.backup_current_state(candidate).await?;
+        let baseline_score = {
+            let meta_path = backup_path.with_extension("meta.json");
+            if meta_path.exists() {
+                let meta: BackupRecord =
+                    serde_json::from_str(&std::fs::read_to_string(&meta_path)?)?;
+                meta.baseline_score
+            } else {
+                None
+            }
+        };
+
+        // Gate 2: Apply — write new prompt to config
+        if let Err(e) = self.apply_prompt(candidate).await {
+            warn!(error = %e, "failed to apply prompt, skipping post-hook");
+            return Err(e);
+        }
+
+        // Gate 3: Post-hook — benchmark and auto-rollback
+        match self.run_benchmarks().await {
+            Ok(new_result) => {
+                // Check for regression
+                if let Some(baseline) = baseline_score {
+                    let regression = baseline - new_result.score;
+                    let regression_pct = regression / baseline;
+
+                    info!(
+                        baseline = baseline,
+                        new_score = new_result.score,
+                        regression = regression,
+                        regression_pct = regression_pct,
+                        threshold = self.regression_threshold,
+                        "benchmark comparison"
+                    );
+
+                    if regression_pct > self.regression_threshold {
+                        warn!(
+                            regression_pct = regression_pct,
+                            threshold = self.regression_threshold,
+                            "performance regression detected, triggering rollback"
+                        );
+                        self.rollback(&backup_path).await?;
+                        anyhow::bail!(
+                            "evolution rejected: performance regressed {:.1}% (threshold: {:.1}%)",
+                            regression_pct * 100.0,
+                            self.regression_threshold * 100.0
+                        );
+                    }
+                } else {
+                    info!("no baseline available, accepting new prompt without regression check");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "benchmark failed, rolling back as safety measure");
+                self.rollback(&backup_path).await?;
+                return Err(e);
+            }
+        }
+
+        // Cleanup old backups
+        let _ = self.cleanup_old_backups().await;
+
+        info!(
+            candidate_id = %candidate.id,
+            description = %candidate.description,
+            "evolution applied successfully with safety gates"
+        );
+
+        Ok(())
+    }
+}
+
+fn config_path() -> PathBuf {
+    let mut p = dirs_home().unwrap_or_else(|| PathBuf::from("."));
+    p.push(".paperclip/harness/config.toml");
+    p
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    #[cfg(windows)]
+    return std::env::var("USERPROFILE").ok().map(PathBuf::from);
+    #[cfg(not(windows))]
+    return std::env::var("HOME").ok().map(PathBuf::from);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn test_safe_applier_backup_and_rollback() {
+        let temp_dir = std::env::temp_dir().join(format!("safe-applier-test-{}", Uuid::new_v4()));
+        let backup_dir = temp_dir.join("backups");
+        let benchmark_script = temp_dir.join("benchmark.sh");
+
+        // Create a dummy benchmark script that returns success
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        std::fs::write(
+            &benchmark_script,
+            r#"#!/bin/bash
+echo '{"score": 0.95, "metrics": {"build_success": 1.0, "test_pass_rate": 0.9, "clippy_clean": 1.0, "fmt_clean": 1.0}}'
+"#,
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&benchmark_script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&benchmark_script, perms).unwrap();
+        }
+
+        let applier = SafeApplier::with_paths(backup_dir.clone(), benchmark_script);
+
+        let candidate = PromptCandidate {
+            id: Uuid::new_v4(),
+            prompt: "Test prompt".to_string(),
+            description: "Test candidate".to_string(),
+        };
+
+        // Test backup creation
+        let backup_path = applier.backup_current_state(&candidate).await.unwrap();
+        assert!(backup_path.exists());
+        assert!(backup_dir
+            .join(format!(
+                "{}.meta.json",
+                backup_path.file_stem().unwrap().to_string_lossy()
+            ))
+            .exists());
+
+        // Cleanup
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_benchmark_parsing() {
+        let temp_dir = std::env::temp_dir().join(format!("benchmark-test-{}", Uuid::new_v4()));
+        let benchmark_script = temp_dir.join("benchmark.sh");
+
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        std::fs::write(
+            &benchmark_script,
+            r#"#!/bin/bash
+echo '{"score": 0.85, "metrics": {"build_success": 1.0, "test_pass_rate": 0.8, "clippy_clean": 0.9, "fmt_clean": 1.0}}'
+"#,
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&benchmark_script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&benchmark_script, perms).unwrap();
+        }
+
+        let applier = SafeApplier::with_paths(temp_dir.join("backups"), benchmark_script);
+        let result = applier.run_benchmarks().await.unwrap();
+
+        assert_eq!(result.score, 0.85);
+        assert_eq!(result.metrics.build_success, 1.0);
+        assert_eq!(result.metrics.test_pass_rate, 0.8);
+
+        // Cleanup
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+}

--- a/scripts/run-evolution-benchmarks.sh
+++ b/scripts/run-evolution-benchmarks.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Evolution benchmark runner — validates prompt quality through build/test/lint metrics.
+#
+# Outputs JSON in the format:
+# {
+#   "score": 0.0-1.0,
+#   "metrics": {
+#     "build_success": 0.0-1.0,
+#     "test_pass_rate": 0.0-1.0,
+#     "clippy_clean": 0.0-1.0,
+#     "fmt_clean": 0.0-1.0
+#   }
+# }
+
+set -euo pipefail
+
+# Navigate to project root
+cd "$(dirname "$0")/.."
+
+# Metrics (default to 0.0, set to 1.0 on success)
+build_success=0.0
+test_pass_rate=0.0
+clippy_clean=0.0
+fmt_clean=0.0
+
+# 1. Build check (25% weight)
+if cargo build --workspace --all-targets 2>/dev/null; then
+    build_success=1.0
+fi
+
+# 2. Test pass rate (35% weight)
+if cargo test --workspace --no-fail-fast 2>&1 | tee /tmp/test-output.txt; then
+    # Parse test results to get pass rate
+    passed=$(grep -oP '\d+(?= passed)' /tmp/test-output.txt | tail -1 || echo "0")
+    failed=$(grep -oP '\d+(?= failed)' /tmp/test-output.txt | tail -1 || echo "0")
+    total=$((passed + failed))
+
+    if [ "$total" -gt 0 ]; then
+        test_pass_rate=$(awk "BEGIN {printf \"%.2f\", $passed / $total}")
+    else
+        # No tests = assume passing
+        test_pass_rate=1.0
+    fi
+else
+    # Tests failed, but still calculate pass rate from output
+    passed=$(grep -oP '\d+(?= passed)' /tmp/test-output.txt | tail -1 || echo "0")
+    failed=$(grep -oP '\d+(?= failed)' /tmp/test-output.txt | tail -1 || echo "0")
+    total=$((passed + failed))
+
+    if [ "$total" -gt 0 ]; then
+        test_pass_rate=$(awk "BEGIN {printf \"%.2f\", $passed / $total}")
+    fi
+fi
+
+# 3. Clippy clean (20% weight)
+if cargo clippy --workspace --all-targets -- -D warnings 2>/dev/null; then
+    clippy_clean=1.0
+fi
+
+# 4. Fmt clean (20% weight)
+if cargo fmt --all -- --check 2>/dev/null; then
+    fmt_clean=1.0
+fi
+
+# Calculate weighted overall score
+# Weights: build=0.25, test=0.35, clippy=0.20, fmt=0.20
+score=$(awk "BEGIN {
+    score = ($build_success * 0.25) + \
+            ($test_pass_rate * 0.35) + \
+            ($clippy_clean * 0.20) + \
+            ($fmt_clean * 0.20);
+    printf \"%.3f\", score
+}")
+
+# Output JSON
+cat <<EOF
+{
+  "score": $score,
+  "metrics": {
+    "build_success": $build_success,
+    "test_pass_rate": $test_pass_rate,
+    "clippy_clean": $clippy_clean,
+    "fmt_clean": $fmt_clean
+  }
+}
+EOF


### PR DESCRIPTION
## Summary

Implements **Safety Gates** for Anvil's 5-gate self-evolution engine using the APT (Agentic Prompt Template) pattern. Prevents performance degradation through automatic benchmark validation and rollback.

This addresses **ANGA-900** from the APT pattern brainstorm (ANGA-865, Priority 1).

### Changes

- **SafeApplier**: New `Applier` trait implementation with three safety gates:
  1. **Pre-hook**: Backs up current prompt and captures baseline benchmark scores
  2. **Apply**: Writes evolved prompt to `~/.paperclip/harness/config.toml`
  3. **Post-hook**: Runs benchmarks, compares to baseline, auto-rolls back if regression >10%

- **Benchmark runner**: Shell script (`scripts/run-evolution-benchmarks.sh`) that measures:
  - Build success (25%)
  - Test pass rate (35%)
  - Clippy clean (20%)
  - Fmt clean (20%)

- **Backup management**: Timestamped backups in `~/.paperclip/harness/prompt-backups/`, keeps last 10

- **Integration**: `default_engine()` now uses `SafeApplier` instead of `DefaultApplier`

- **Documentation**: Added `crates/evolution/SAFETY_GATES.md` with full spec

### Files Changed

- `crates/evolution/src/safe_applier.rs` (new, 430 lines) — APT safety gates implementation
- `crates/evolution/src/defaults.rs` — Updated `default_engine()` to use SafeApplier
- `crates/evolution/src/lib.rs` — Export SafeApplier
- `scripts/run-evolution-benchmarks.sh` (new, 86 lines) — Benchmark runner
- `crates/evolution/SAFETY_GATES.md` (new, 178 lines) — Documentation

## Test Plan

- [x] SafeApplier unit tests (backup creation, benchmark parsing)
- [ ] Manual test: trigger evolution with SafeApplier
- [ ] Verify backup directory creation
- [ ] Verify benchmark script execution
- [ ] Test auto-rollback on simulated regression
- [ ] Verify cleanup of old backups
- [ ] CI checks (build, clippy, fmt)

## Verification (from ANGA-900)

- [x] Pre-hook backs up current version before applying evolved prompt
- [x] Post-hook runs full benchmark suite and compares to baseline
- [x] Auto-rollback triggers if performance regresses > 10%

## Related

- **ANGA-900**: https://paperclip.ing/ANGA/issues/ANGA-900
- **ANGA-865**: APT Pattern Brainstorm (parent)
- **ANGA-901**: `/review-self` command (APT pattern reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)