### PR TITLE
Add upstream conflict check to issue templates (ANGA-554)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Environment
+- Anvil version:
+- Rust version:
+- OS:
+
+## Upstream Conflict Check
+<!-- Required for bugs touching: error/failure taxonomy, database schemas, agent configuration, or platform-level abstractions -->
+
+- [ ] Searched upstream tracker (https://github.com/anthropics/claude-code/issues) for related in-flight work
+- **Keywords searched:**
+- **Related upstream issues:** (or "None found")
+- **Why this is fork-specific:** (if applicable)
+
+## Additional Context
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Objective
+<!-- One sentence: what this feature achieves and why it matters -->
+
+## Scope
+**Touch:** <!-- files, systems, or areas to modify -->
+
+**Do not touch:** <!-- explicit exclusions to prevent scope creep -->
+
+## Verification
+- [ ] <!-- Concrete, machine-checkable acceptance criterion -->
+- [ ] <!-- Another criterion if needed -->
+
+## Upstream Conflict Check
+<!-- **REQUIRED** for features touching: error/failure taxonomy, database schemas, agent configuration, or platform-level abstractions -->
+
+- [ ] Searched upstream tracker (https://github.com/anthropics/claude-code/issues) for related in-flight work
+- **Keywords searched:**
+- **Related upstream issues:** (or "None found")
+- **Why this is fork-specific:** (if applicable)
+
+## Context
+<!-- Background info, links to related issues, motivation -->
+
+## Constraints
+<!-- Max iterations, time bounds, on-failure behavior (optional) -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,25 @@ summarizing what was done. The CTO will review and merge.
 
 ---
 
+## Fork Workflow — Upstream Search Requirement
+
+**Anvil is a fork of Claude Code.** Before filing issues touching cross-cutting concerns, search the
+upstream tracker (https://github.com/anthropics/claude-code/issues) to prevent parallel implementation.
+
+**Scope gate applies to:**
+- Error/failure taxonomy
+- Database schemas
+- Agent configuration patterns
+- Platform-level abstractions
+
+**Required checklist item:**
+- [ ] Searched upstream tracker for related in-flight work
+- [ ] Documented keywords searched, related issues found (or "None"), and why this is fork-specific
+
+See issue templates in `.github/ISSUE_TEMPLATE/` for the required format.
+
+---
+
 ## Roadmap context
 
 The project has completed through **Phase 6**:


### PR DESCRIPTION
## Summary
- Add scoping gate to prevent parallel implementation of cross-cutting concerns in fork and upstream
- Created bug_report.md and feature_request.md templates with upstream conflict check section
- Updated AGENTS.md with upstream search requirement

## Context
Implements ANGA-554: https://paperclip.ing/ANGA/issues/ANGA-554

Prevents duplicate work between Anvil (Claude Code fork) and upstream by requiring upstream tracker search before filing issues on:
- Error/failure taxonomy
- Database schemas
- Agent configuration
- Platform-level abstractions

## Test plan
- [ ] Bug report template renders correctly on GitHub
- [ ] Feature request template renders correctly on GitHub  
- [ ] AGENTS.md updated with clear upstream search requirement
- [ ] Templates include all required fields from ANGA-554 verification criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)