### PR TITLE
fix(cli,core): address dogfood pain points from ANGA-553 session

### DIFF
--- a/crates/cli/src/commands/memory.rs
+++ b/crates/cli/src/commands/memory.rs
@@ -17,9 +17,9 @@ enum MemoryCommands {
         #[arg(short, long, default_value = "10")]
         limit: i64,
     },
-    /// Show recent episodes for a session
+    /// Show recent episodes for a session (accepts UUID or session name from --session)
     Recent {
-        session_id: Uuid,
+        session: String,
         #[arg(short, long, default_value = "20")]
         limit: i64,
     },
@@ -44,8 +44,16 @@ pub async fn execute(args: MemoryArgs) -> anyhow::Result<()> {
                 );
             }
         }
-        MemoryCommands::Recent { session_id, limit } => {
-            let results = memory.recent(session_id, limit).await?;
+        MemoryCommands::Recent { session, limit } => {
+            // Accept either a full UUID or a human-readable session name.
+            let results = if let Ok(uuid) = Uuid::parse_str(&session) {
+                memory.recent(uuid, limit).await?
+            } else {
+                memory.recent_by_name(&session, limit).await?
+            };
+            if results.is_empty() {
+                println!("No episodes found for session: {session}");
+            }
             for ep in results {
                 println!(
                     "[{}] {}: {}",

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -344,11 +344,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         }
 
         ui::print_session_summary(0, 0, session.iteration, elapsed_ms);
-        eprintln!(
-            "  session {} | status {:?}",
-            session.id,
-            session.status,
-        );
+        eprintln!("  session {} | status {:?}", session.id, session.status,);
     }
 
     Ok(())

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -346,7 +346,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         ui::print_session_summary(0, 0, session.iteration, elapsed_ms);
         eprintln!(
             "  session {} | status {:?}",
-            &session.id.to_string()[..8],
+            session.id,
             session.status,
         );
     }

--- a/crates/core/src/providers/claude_code.rs
+++ b/crates/core/src/providers/claude_code.rs
@@ -166,6 +166,7 @@ impl Provider for ClaudeCodeProvider {
                 &prompt,
                 "--output-format",
                 "stream-json",
+                "--verbose",
                 "--model",
                 &self.model,
                 "--no-session-persistence",


### PR DESCRIPTION
## Summary

Three fixes from live dogfood run on Anvil (ANGA-553):

- **Stream regression** ([ANGA-995](/ANGA/issues/ANGA-995)): `--stream --provider cc` was failing with `stream-json requires --verbose`. Added `--verbose` to the cc subprocess stream invocation.
- **Memory recall by session name** ([ANGA-996](/ANGA/issues/ANGA-996)): `anvil memory recent <name>` now works with human-readable session names from `--session`, not just UUIDs. Routes to `recent_by_name()` when argument is not a valid UUID.
- **Full session UUID in footer**: Footer now shows the complete UUID instead of an 8-char prefix, making `memory recent <uuid>` copy-paste friendly.

## Test plan

- [ ] `anvil run --stream --provider cc --goal "..."` completes without error
- [ ] `anvil memory recent dogfood-test` returns episodes (named session)
- [ ] `anvil memory recent <full-uuid>` still works (backward compat)
- [ ] CI green on all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)