### PR TITLE
fix(tools): allow iterative edits after a write; clarify config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Anvil
 
-> A Rust-native agent harness. One binary, pluggable LLM providers, sub-agents, a skill library and persistent episodic memory.
+> A coding agent that runs **fully offline as a single binary** — no Node, no Python, no API key.
+> Tool-calling loop, sub-agents, a skill library and persistent memory, all against a local Ollama model.
 
 **Status:** v0.1.0, pre-release. Builds and tests clean on `main`; the CLI surface below is what actually ships.
 
@@ -17,6 +18,17 @@ Anvil is a single-binary agent harness:
 1. `anvil run --goal "..."` starts an agent turn loop against your configured LLM provider.
 2. The agent calls tools (bash, file read/write, grep), can spawn sub-agents up to a depth of 4, and can read, save and refine Markdown skills in `~/.anvil/skills/`.
 3. Every turn is written to a SQLite episodic memory you can search from the CLI.
+
+### Why pick it over Claude Code, Codex or aider?
+
+Only for the things those tools structurally can't do:
+
+- **It runs with no network and no account.** One static binary plus Ollama. Air-gapped machines, and zero marginal cost per run.
+- **No language runtime to install.** `cargo install` once; there is no `node_modules`, no venv.
+- **It is a library, not just a CLI.** The agent loop, tool registry and memory store are ordinary Rust crates you can embed in your own program.
+- **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result.
+
+Where it does **not** compete: interactive day-to-day coding. Against a frontier model those tools are far faster and far more capable. On a local 9.6 GB model a single edit-build-fix task here takes roughly 3 minutes.
 
 ---
 
@@ -43,6 +55,17 @@ ollama pull qwen2.5:3b-instruct
 
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Say hello in exactly three words."
 ```
+
+### Choosing a local model
+
+Tool-calling ability matters far more than speed here.
+
+| Task | Works on a 3B model? |
+|------|----------------------|
+| Read files, grep, answer a question about a codebase | Yes |
+| Edit a file, run a build, fix the error, re-run | **No** — small models tend to *describe* the edit and end the turn without calling `write_file` |
+
+For anything that edits files, use a larger tool-calling model (`gemma4`, `qwen3.6:27b-q4_K_M` or similar). Pick with `--model`.
 
 No LLM at all? The `echo` provider mirrors input back and is what the test suite uses:
 
@@ -109,6 +132,15 @@ anvil auth status
 
 Episodes are stored in `~/.paperclip/harness/memory.db` (SQLite + FTS5), alongside config at `~/.paperclip/harness/config.toml`.
 
+There are **two** ways past episodes reach the model, and only the first is opt-in:
+
+1. **Named sessions.** `--session <name>` replays that session's prior episodes as real conversation turns, up to `memory.max_context_episodes` (default 20).
+2. **Global recall — always on.** Every run, with or without `--session`, full-text-searches *all* episodes for the goal text and prepends up to 5 matches (200 chars each) to the system prompt.
+
+Because of (2), `--session` is **not** an isolation boundary: a run under one session name can recall facts recorded under another. Everything written to the database is visible to every later run by the same user. Don't put anything in a goal you wouldn't want recalled in an unrelated project.
+
+Both paths are per-user, not per-directory — there is no way to point Anvil at a different database short of changing `$HOME`.
+
 ---
 
 ## Architecture
@@ -124,6 +156,12 @@ crates/
 ```
 
 Tools registered in the shipped binary: `echo`, `read_file`, `write_file`, `grep`, `bash`, `spawn_subagent`, `list_skills`, `read_skill`, `save_skill`, `refine_skill`.
+
+Limits worth knowing before you hit them:
+
+- **`bash` commands time out after 30 seconds** and are restricted to an allowlist (`cargo`, `git`, `ls`, `cat`, `grep`, `curl`, `jq`, …). A cold `cargo build` on a non-trivial project will exceed this.
+- **`write_file` requires a prior `read_file`** of that path in the same session, and refuses to write if the file changed since that read. Creating a new file is exempt.
+- **Paths are relative only** — absolute paths and `..` are rejected. Anvil operates on the current working directory.
 
 ### Crates not wired into the binary
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -19,10 +19,47 @@ pub async fn execute(args: ConfigArgs) -> anyhow::Result<()> {
     println!("Agent name: {}", config.agent.name);
 
     if args.check {
-        match config.resolved_api_key() {
-            Some(_) => println!("API key:    [set]"),
-            None => println!("API key:    [NOT SET] ← set ANTHROPIC_API_KEY"),
-        }
+        println!("Credentials: {}", credential_status(&config));
     }
     Ok(())
+}
+
+/// Only the `claude` backend reads `ANTHROPIC_API_KEY`; `claude-code` shells out
+/// to the `claude` CLI and `ollama`/`echo` need no credentials at all. Reporting
+/// a missing key for those backends sends new users hunting for a key they will
+/// never need.
+fn credential_status(config: &Config) -> String {
+    match config.provider.backend.as_str() {
+        "claude" => match config.resolved_api_key() {
+            Some(_) => "[set]".to_string(),
+            None => "[NOT SET] ← set ANTHROPIC_API_KEY, or run `claude auth login`".to_string(),
+        },
+        "claude-code" | "cc" => {
+            "not required — this backend runs the `claude` CLI (must be on PATH)".to_string()
+        }
+        other => format!("not required by the `{other}` backend"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_backend(backend: &str) -> Config {
+        let mut c = Config::default();
+        c.provider.backend = backend.to_string();
+        c
+    }
+
+    #[test]
+    fn keyless_backends_do_not_demand_an_api_key() {
+        // The regression: these used to print "[NOT SET] <- set ANTHROPIC_API_KEY".
+        for backend in ["ollama", "echo", "claude-code", "cc"] {
+            let status = credential_status(&config_with_backend(backend));
+            assert!(
+                !status.contains("ANTHROPIC_API_KEY"),
+                "{backend} should not ask for ANTHROPIC_API_KEY, got: {status}"
+            );
+        }
+    }
 }

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -3,7 +3,7 @@ use harness_core::config::Config;
 
 #[derive(Args)]
 pub struct ConfigArgs {
-    /// Show resolved API key presence
+    /// Also report whether the configured backend has the credentials it needs
     #[arg(long)]
     pub check: bool,
 }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -210,17 +210,6 @@ fn get_read_snapshot(context: &ToolCallContext, path_key: &str) -> Option<String
     })
 }
 
-fn invalidate_read_snapshot(context: &ToolCallContext, path_key: &str) {
-    if let Ok(mut state) = safe_edit_state().lock() {
-        if let Some(paths) = state
-            .snapshots_by_session
-            .get_mut(&safe_edit_session_key(context))
-        {
-            paths.remove(path_key);
-        }
-    }
-}
-
 #[cfg(test)]
 fn reset_safe_edit_state_for_tests() {
     if let Ok(mut state) = safe_edit_state().lock() {
@@ -492,8 +481,13 @@ impl ToolHandler for WriteFileTool {
 
         match std::fs::write(&raw, &new_text) {
             Ok(()) => {
-                // Force a fresh read before subsequent overwrites.
-                invalidate_read_snapshot(context, &path_key);
+                // The write just made `new_text` the on-disk truth, and the agent
+                // authored it, so it is as good as a fresh read: record it as the
+                // current snapshot. Dropping it instead would block every
+                // subsequent edit of the same file in the session, while adding no
+                // safety -- a concurrent external change is still caught by the
+                // snapshot comparison above.
+                record_read_snapshot(context, &path_key, &new_text);
                 ToolOutput::ok(format!("wrote {} bytes to {raw}", new_text.len()))
             }
             Err(e) => ToolOutput::err(format!("write_file failed for {raw}: {e}")),
@@ -654,6 +648,59 @@ mod tests {
             out.content.contains("requires a prior read_file"),
             "expected read-before-write guard, got: {}",
             out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_allows_repeated_edits_after_one_read() {
+        let _scope = enter_test_fs_scope().await;
+        std::fs::write("iterate.txt", "v1").expect("seed file");
+
+        let read = ReadFileTool.call(json!({"path":"iterate.txt"})).await;
+        assert!(!read.is_error, "read failed: {}", read.content);
+
+        let first = WriteFileTool
+            .call(json!({"path":"iterate.txt","content":"v2"}))
+            .await;
+        assert!(!first.is_error, "first write failed: {}", first.content);
+
+        // Iterating on a file the agent just wrote must not require re-reading it.
+        let second = WriteFileTool
+            .call(json!({"path":"iterate.txt","content":"v3"}))
+            .await;
+        assert!(
+            !second.is_error,
+            "second write should be allowed after the first: {}",
+            second.content
+        );
+        assert_eq!(
+            std::fs::read_to_string("iterate.txt").expect("read back"),
+            "v3"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_allows_overwriting_a_file_it_just_created() {
+        let _scope = enter_test_fs_scope().await;
+
+        // Creating a new file needs no prior read -- there is nothing to clobber.
+        let create = WriteFileTool
+            .call(json!({"path":"created.txt","content":"v1"}))
+            .await;
+        assert!(!create.is_error, "create failed: {}", create.content);
+
+        // ...and the agent may then refine it without an intervening read_file.
+        let overwrite = WriteFileTool
+            .call(json!({"path":"created.txt","content":"v2"}))
+            .await;
+        assert!(
+            !overwrite.is_error,
+            "overwrite of just-created file should be allowed: {}",
+            overwrite.content
+        );
+        assert_eq!(
+            std::fs::read_to_string("created.txt").expect("read back"),
+            "v2"
         );
     }
 


### PR DESCRIPTION
Found by dogfooding Anvil on real tasks against a local Ollama model (`gemma4:latest`, `qwen2.5:3b-instruct`) — reading a codebase, editing a file, interpreting a build failure, sub-agents, skills, and memory across sessions.

## 1. `write_file` could not edit the same file twice (the real bug)

`WriteFileTool` called `invalidate_read_snapshot` after every successful write, deleting the file's read snapshot. The next `write_file` on that path then failed with `SafeEdit violation: write_file requires a prior read_file` — even though the agent had just authored the contents. **An agent could never iterate on a file.**

Observed on a task that just had to fix one compiler error:

| | before | after |
|---|---|---|
| iterations | 15 (budget exhausted) | 6 |
| wall clock | 450s | 185s |
| `SafeEdit` violations | 9 | 0 |
| project compiles | no | yes |

The fix records the just-written contents as the new snapshot instead of dropping it. **The guard is not weakened**: a concurrent *external* modification is still caught by the existing snapshot comparison, because the snapshot continues to reflect on-disk truth. `write_file_rejects_stale_snapshot` still passes.

Two regression tests added: iterating on an existing file, and overwriting a file the agent just created.

## 2. `anvil config --check` demanded a key nobody needed

It printed `API key: [NOT SET] ← set ANTHROPIC_API_KEY` regardless of backend. Only `claude` reads that variable — `claude-code` (the default) shells out to the `claude` CLI, and `ollama`/`echo` need no credentials. New users were sent hunting for a key they never need.

```
Credentials: not required — this backend runs the `claude` CLI (must be on PATH)
```

## 3. README

- Leads with **why you'd pick Anvil** — offline, single static binary, no language runtime, embeddable as Rust crates, NDJSON output — instead of "a Rust-native agent harness", which describes the implementation rather than the reason to use it. Also states plainly where it does *not* compete.
- Documents that `--session` is **not** an isolation boundary: a second, always-on recall path full-text-searches *all* episodes on every run and prepends up to 5 to the system prompt. Verified: a run under a fresh session name, in a clean directory, with a reworded question and zero tool calls, recalled a fact recorded under a different session.
- Documents the 30s `bash` timeout and the read-before-write rule.
- Adds model guidance: 3B models read code fine but tend to *describe* an edit and end the turn without calling `write_file`.

## Verification

`cargo test --workspace` 78 passed (was 75) · `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean · `cargo fmt --all -- --check` clean.

Deliberately **not** included, reported separately as they change behaviour that deserves your call: the 30s bash cap (Anvil cannot build itself — a cold `cargo build` here takes 59s), `recent_by_name`'s `ORDER BY created_at ASC LIMIT` returning the *oldest* 20 episodes rather than the newest, the inverted assistant-before-user episode insert order, and the turn loop accepting a bare-text turn as task completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)