### PR TITLE
feat(local): make the Ollama path survive small-model protocol slips

### DIFF
--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -554,6 +554,24 @@ impl Agent {
                         });
                     }
 
+                    // A model that re-issues the identical call will keep doing
+                    // so until the iteration cap: the tool result it just got is
+                    // the same one it already ignored, so nothing in the context
+                    // pushes it elsewhere. Say so explicitly on the channel it is
+                    // already reading.
+                    if repeated_tool_call {
+                        if let Some(ContentBlock::ToolResult { content, .. }) =
+                            result_blocks.first_mut()
+                        {
+                            content.push_str(
+                                "\n\n[harness] This is the same tool call, with the same \
+                                 arguments, as your previous turn — so this is the same result. \
+                                 Repeating it again will not help. Either use this output to \
+                                 answer, or try a materially different command.",
+                            );
+                        }
+                    }
+
                     // Feed results back as a tool-role message and continue.
                     let tool_result_msg = Message {
                         role: Role::Tool,

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -1090,4 +1090,126 @@ mod tests {
             "expected prior session history to be injected; messages: {all_text:?}"
         );
     }
+    /// The failure that motivated the recovery path: the model writes the tool
+    /// call into the message body and ends its turn. Before, the loop read that
+    /// as a final answer and stopped one step from success.
+    #[tokio::test]
+    async fn tool_call_written_as_text_is_executed() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            end_turn_response(
+                "I'll check that.\n```json\n{\"name\": \"echo\", \"input\": {\"message\": \"ping\"}}\n```",
+            ),
+            end_turn_response("done"),
+        ]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+
+        // The recovered call must have actually run: a tool-result message is
+        // present and carries the echoed payload.
+        let echoed = session.messages.iter().any(|m| {
+            m.role == Role::Tool
+                && match &m.content {
+                    MessageContent::Blocks(b) => b.iter().any(|blk| {
+                        matches!(blk, ContentBlock::ToolResult { content, .. } if content.contains("ping"))
+                    }),
+                    MessageContent::Text(t) => t.contains("ping"),
+                }
+        });
+        assert!(
+            echoed,
+            "expected the text-written tool call to execute, got: {:?}",
+            session.messages
+        );
+    }
+
+    /// A truncated fence — the model stopped mid-JSON — is still recoverable.
+    #[tokio::test]
+    async fn truncated_text_tool_call_is_recovered() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            end_turn_response("Here:\n```json\n{\"name\": \"echo\", \"input\": {\"message\": \"ping\""),
+            end_turn_response("done"),
+        ]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert!(session.messages.iter().any(|m| m.role == Role::Tool));
+    }
+
+    /// Ordinary prose must not be mistaken for a tool call — otherwise every
+    /// final answer mentioning JSON would restart the loop.
+    #[tokio::test]
+    async fn plain_final_answer_still_ends_the_run() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response(
+            "There are no TODO comments in crates/.",
+        )]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert!(
+            !session.messages.iter().any(|m| m.role == Role::Tool),
+            "no tool should have run for a plain prose answer"
+        );
+    }
+
+    /// An unknown tool name must not be executed just because it parsed.
+    #[tokio::test]
+    async fn text_call_to_unknown_tool_is_not_executed() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response(
+            "```json\n{\"name\": \"rm_rf\", \"input\": {\"path\": \"/\"}}\n```",
+        )]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert!(!session.messages.iter().any(|m| m.role == Role::Tool));
+    }
 }

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -21,6 +21,11 @@ use tracing::{debug, info, warn};
 /// Maximum sub-agent nesting depth to prevent infinite recursion.
 const MAX_SUBAGENT_DEPTH: usize = 4;
 
+/// How many times per run a tool call written as text may be recovered and
+/// executed. Bounded so a model that never uses the native channel still
+/// terminates instead of looping.
+const MAX_TEXT_CALL_RECOVERIES: usize = 3;
+
 /// Callback interface for terminal UI events emitted by the agent loop.
 ///
 /// The default no-op implementation is used for sub-agents and tests so they
@@ -60,10 +65,41 @@ pub trait UiHook: Send + Sync {
     fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
         let _ = (text, is_error, session_id);
     }
+    /// Called once per completed provider turn with structural diagnostics.
+    ///
+    /// Exists so the failure taxonomy of a run is *measured* rather than inferred
+    /// from the rendered text. Default: no-op.
+    fn on_turn_diag(&self, diag: &TurnDiag) {
+        let _ = diag;
+    }
     /// Called while waiting for the provider to return; receives `[current/max]` label.
     fn on_thinking(&self, iteration: usize, max_iter: usize);
     /// Called when the provider has returned (end of thinking).
     fn on_thinking_done(&self);
+}
+
+/// Structural facts about one completed provider turn.
+///
+/// Emitted for every turn so a run's failure mode can be classified from ground
+/// truth (what the model actually returned) instead of regexing rendered prose.
+#[derive(Debug, Clone)]
+pub struct TurnDiag {
+    /// 1-based turn index within the run.
+    pub iteration: usize,
+    /// Provider-reported stop reason, as a stable lowercase string.
+    pub stop_reason: &'static str,
+    /// Number of text blocks in the assistant message.
+    pub text_blocks: usize,
+    /// Number of native tool-use blocks in the assistant message.
+    pub tool_blocks: usize,
+    /// True when the turn carried neither text nor a tool call (the Ollama
+    /// empty-completion flake).
+    pub empty: bool,
+    /// Number of tool calls recovered from assistant *text* because the model
+    /// wrote them as prose instead of using the native tool channel.
+    pub recovered_text_calls: usize,
+    /// True when this turn's tool calls exactly repeated the previous turn's.
+    pub repeated_tool_call: bool,
 }
 
 /// Silent implementation used for sub-agents and unit tests.
@@ -257,6 +293,11 @@ impl Agent {
             .map(harness_tools::ToolSchema::to_def)
             .collect();
 
+        // Previous turn's (name, input) tool-call signature, for loop detection.
+        let mut prev_call_sig: Vec<(String, serde_json::Value)> = Vec::new();
+        // Bounded so a model that only ever writes prose cannot spin here.
+        let mut recoveries_used = 0usize;
+
         loop {
             if session.iteration >= max_iter {
                 info!("max iterations reached");
@@ -275,11 +316,50 @@ impl Agent {
             );
 
             self.hook.on_thinking(session.iteration, max_iter);
-            let response = self
+            let mut response = self
                 .provider
                 .complete_with_tools(&messages, &tool_defs)
                 .await?;
             self.hook.on_thinking_done();
+
+            // -- Recover tool calls the model wrote as text ------------------------
+            // Small local models regularly drop out of the native tool-call
+            // channel and write the call into the message body instead. Without
+            // this the loop reads that as an ordinary end-of-turn and abandons
+            // the task one step from success. Bounded per run so a model that
+            // only ever emits text cannot spin here.
+            let mut recovered_text_calls = 0usize;
+            if response.stop_reason != StopReason::ToolUse
+                && recoveries_used < MAX_TEXT_CALL_RECOVERIES
+            {
+                if let Some(text) = response.message.text() {
+                    let known: Vec<String> =
+                        self.tools.schemas().iter().map(|s| s.name.clone()).collect();
+                    let calls: Vec<_> = harness_core::toolcall_text::parse_text_tool_calls(text)
+                        .into_iter()
+                        .filter(|c| known.iter().any(|k| k == &c.name))
+                        .collect();
+                    if !calls.is_empty() {
+                        recovered_text_calls = calls.len();
+                        recoveries_used += 1;
+                        warn!(
+                            count = calls.len(),
+                            "recovered tool call(s) written as text; executing them"
+                        );
+                        let blocks = calls
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, c)| ContentBlock::ToolUse {
+                                id: format!("recovered_{}_{i}", session.iteration),
+                                name: c.name,
+                                input: c.input,
+                            })
+                            .collect();
+                        response.message.content = MessageContent::Blocks(blocks);
+                        response.stop_reason = StopReason::ToolUse;
+                    }
+                }
+            }
 
             let preview = response.message.text().unwrap_or("").to_string();
             info!(
@@ -289,6 +369,44 @@ impl Agent {
                 "response: {}",
                 &preview[..preview.len().min(120)]
             );
+
+            // -- Turn diagnostics -------------------------------------------------
+            // Emitted before any behavioural branch so the taxonomy reflects what
+            // the model actually returned, not what the loop did about it.
+            let (text_blocks, tool_blocks, call_sig) = match &response.message.content {
+                MessageContent::Blocks(blocks) => {
+                    let mut texts = 0usize;
+                    let mut sig = Vec::new();
+                    for b in blocks {
+                        match b {
+                            ContentBlock::Text { text } if !text.is_empty() => texts += 1,
+                            ContentBlock::ToolUse { name, input, .. } => {
+                                sig.push((name.clone(), input.clone()));
+                            }
+                            _ => {}
+                        }
+                    }
+                    (texts, sig.len(), sig)
+                }
+                MessageContent::Text(t) => (usize::from(!t.is_empty()), 0, Vec::new()),
+            };
+            let repeated_tool_call = !call_sig.is_empty() && call_sig == prev_call_sig;
+            prev_call_sig = call_sig;
+
+            self.hook.on_turn_diag(&TurnDiag {
+                iteration: session.iteration,
+                stop_reason: match response.stop_reason {
+                    StopReason::EndTurn => "end_turn",
+                    StopReason::ToolUse => "tool_use",
+                    StopReason::MaxTokens => "max_tokens",
+                    StopReason::StopSequence => "stop_sequence",
+                },
+                text_blocks,
+                tool_blocks,
+                empty: text_blocks == 0 && tool_blocks == 0,
+                recovered_text_calls,
+                repeated_tool_call,
+            });
 
             // Append assistant message to running history and session log.
             messages.push(response.message.clone());

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -52,6 +52,11 @@ pub struct RunArgs {
     /// Use this flag when calling `anvil run` from a machine-readable context (e.g. Paperclip adapter).
     #[arg(long)]
     pub json_output: bool,
+
+    /// Sampling temperature for local (Ollama) models. Lower is more literal;
+    /// the default suits tool-calling. Ignored by hosted providers.
+    #[arg(long)]
+    pub temperature: Option<f32>,
 }
 
 // ── Terminal (coloured) hook ──────────────────────────────────────────────────
@@ -212,6 +217,21 @@ impl UiHook for JsonHook {
         }));
     }
 
+    fn on_turn_diag(&self, diag: &crate::agent::TurnDiag) {
+        Self::emit(&serde_json::json!({
+            "type": "turn",
+            "part": {
+                "iteration": diag.iteration,
+                "stopReason": diag.stop_reason,
+                "textBlocks": diag.text_blocks,
+                "toolBlocks": diag.tool_blocks,
+                "empty": diag.empty,
+                "recoveredTextCalls": diag.recovered_text_calls,
+                "repeatedToolCall": diag.repeated_tool_call,
+            }
+        }));
+    }
+
     fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
         Self::emit(&serde_json::json!({
             "type": "result",
@@ -272,11 +292,11 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
                 .as_deref()
                 .unwrap_or("http://localhost:11434");
             tracing::info!(model = %model, base_url = %base_url, "using OllamaProvider");
-            Arc::new(OllamaProvider::new(
-                base_url,
-                &model,
-                config.provider.max_tokens,
-            ))
+            let mut p = OllamaProvider::new(base_url, &model, config.provider.max_tokens);
+            if let Some(t) = args.temperature {
+                p = p.with_temperature(t);
+            }
+            Arc::new(p)
         }
         _ => Arc::new(
             ClaudeProvider::from_env(&model, config.provider.max_tokens)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,3 +7,4 @@ pub mod message;
 pub mod provider;
 pub mod providers;
 pub mod session;
+pub mod toolcall_text;

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -108,3 +108,68 @@ pub struct TurnResponse {
     pub usage: Usage,
     pub model: String,
 }
+
+impl TurnResponse {
+    /// True when the turn carried no usable content at all — no text and no
+    /// tool call.
+    ///
+    /// Distinguishes a provider-level flake (worth retrying) from a model that
+    /// deliberately ended its turn with an answer.
+    #[must_use]
+    pub fn is_empty_turn(&self) -> bool {
+        match &self.message.content {
+            MessageContent::Text(t) => t.trim().is_empty(),
+            MessageContent::Blocks(blocks) => !blocks.iter().any(|b| match b {
+                ContentBlock::Text { text } => !text.trim().is_empty(),
+                ContentBlock::ToolUse { .. } => true,
+                ContentBlock::ToolResult { .. } => false,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod turn_response_tests {
+    use super::{ContentBlock, Message, MessageContent, Role, StopReason, TurnResponse, Usage};
+
+    fn resp(content: MessageContent) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content,
+            },
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            model: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_blocks_is_empty() {
+        assert!(resp(MessageContent::Blocks(vec![])).is_empty_turn());
+    }
+
+    #[test]
+    fn whitespace_only_text_is_empty() {
+        assert!(resp(MessageContent::Text("   \n".into())).is_empty_turn());
+        assert!(resp(MessageContent::Blocks(vec![ContentBlock::Text {
+            text: "  ".into()
+        }]))
+        .is_empty_turn());
+    }
+
+    #[test]
+    fn real_text_is_not_empty() {
+        assert!(!resp(MessageContent::Text("hello".into())).is_empty_turn());
+    }
+
+    #[test]
+    fn tool_call_alone_is_not_empty() {
+        assert!(!resp(MessageContent::Blocks(vec![ContentBlock::ToolUse {
+            id: "1".into(),
+            name: "bash".into(),
+            input: serde_json::json!({}),
+        }]))
+        .is_empty_turn());
+    }
+}

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -10,24 +10,48 @@ use crate::{
     provider::{Provider, StreamChunk, TokenStream, ToolDef},
 };
 
+/// Sampling temperature used when the caller does not specify one.
+///
+/// Ollama's own default is 0.8, which is tuned for open-ended chat. Local
+/// instruct models at that temperature drift out of the tool-call format —
+/// malformed JSON arguments and broken shell quoting. Agentic tool selection
+/// wants near-greedy decoding instead.
+pub const DEFAULT_TEMPERATURE: f32 = 0.2;
+
+/// How many times to re-request a turn that came back completely empty.
+///
+/// Ollama returns a well-formed HTTP 200 with neither content nor tool calls at
+/// a measurable rate on small local models. Without a retry the agent loop reads
+/// it as an ordinary end-of-turn and abandons the task.
+const EMPTY_RESPONSE_RETRIES: usize = 2;
+
 pub struct OllamaProvider {
     client: Client,
     model: String,
     base_url: String,
     max_tokens: u32,
+    temperature: f32,
 }
 
 impl OllamaProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>, max_tokens: u32) -> Self {
         Self {
             client: Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
+                .timeout(std::time::Duration::from_secs(120))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
+            temperature: DEFAULT_TEMPERATURE,
         }
+    }
+
+    /// Override the sampling temperature.
+    #[must_use]
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
     }
 
     fn endpoint(&self) -> String {
@@ -134,6 +158,7 @@ struct OpenAiRequest<'a> {
     messages: Vec<OpenAiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    temperature: f32,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiTool>>,
@@ -238,6 +263,45 @@ impl Provider for OllamaProvider {
         messages: &[Message],
         tools: &[ToolDef],
     ) -> Result<TurnResponse> {
+        // Retry completely empty completions. Ollama returns these at a
+        // measurable rate for small local models; they are a transport-level
+        // flake, not a decision by the model to stop, so re-asking is correct.
+        let mut last = self.complete_once(messages, tools).await?;
+        for attempt in 1..=EMPTY_RESPONSE_RETRIES {
+            if !last.is_empty_turn() {
+                break;
+            }
+            warn!(
+                attempt,
+                model = %self.model,
+                "Ollama returned an empty completion; retrying"
+            );
+            last = self.complete_once(messages, tools).await?;
+        }
+        Ok(last)
+    }
+
+    async fn stream(&self, messages: &[Message]) -> Result<TokenStream> {
+        self.stream_with_tools(messages, &[]).await
+    }
+
+    // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
+    #[allow(clippy::too_many_lines)]
+    async fn stream_with_tools(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<TokenStream> {
+        self.stream_with_tools_inner(messages, tools).await
+    }
+}
+
+impl OllamaProvider {
+    async fn complete_once(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
         let openai_tools = if tools.is_empty() {
             None
         } else {
@@ -260,6 +324,7 @@ impl Provider for OllamaProvider {
             model: &self.model,
             messages: Self::build_openai_messages(messages),
             max_tokens: Some(self.max_tokens),
+            temperature: self.temperature,
             stream: false,
             tools: openai_tools,
             tool_choice: if tools.is_empty() {
@@ -313,17 +378,29 @@ impl Provider for OllamaProvider {
 
         if let Some(tool_calls) = &choice.message.tool_calls {
             for tc in tool_calls {
-                match serde_json::from_str::<serde_json::Value>(&tc.function.arguments) {
-                    Ok(input) => {
-                        blocks.push(ContentBlock::ToolUse {
-                            id: tc.id.clone(),
-                            name: tc.function.name.clone(),
-                            input,
-                        });
-                    }
+                // A native call whose arguments are near-miss JSON (a raw newline
+                // inside a shell command, a trailing comma, a truncated tail) used
+                // to be dropped on the floor, which read to the agent loop as "the
+                // model chose not to call a tool". Repair it instead.
+                let input = match serde_json::from_str::<serde_json::Value>(&tc.function.arguments)
+                {
+                    Ok(v) => Some(v),
                     Err(e) => {
-                        warn!(error = %e, "failed to parse tool arguments from Ollama");
+                        let repaired = crate::toolcall_text::repair_json(&tc.function.arguments);
+                        if repaired.is_some() {
+                            warn!(error = %e, tool = %tc.function.name, "repaired malformed tool arguments from Ollama");
+                        } else {
+                            warn!(error = %e, tool = %tc.function.name, "failed to parse tool arguments from Ollama");
+                        }
+                        repaired
                     }
+                };
+                if let Some(input) = input {
+                    blocks.push(ContentBlock::ToolUse {
+                        id: tc.id.clone(),
+                        name: tc.function.name.clone(),
+                        input,
+                    });
                 }
             }
         }
@@ -348,13 +425,9 @@ impl Provider for OllamaProvider {
         })
     }
 
-    async fn stream(&self, messages: &[Message]) -> Result<TokenStream> {
-        self.stream_with_tools(messages, &[]).await
-    }
-
     // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
     #[allow(clippy::too_many_lines)]
-    async fn stream_with_tools(
+    async fn stream_with_tools_inner(
         &self,
         messages: &[Message],
         tools: &[ToolDef],
@@ -381,6 +454,7 @@ impl Provider for OllamaProvider {
             model: &self.model,
             messages: Self::build_openai_messages(messages),
             max_tokens: Some(self.max_tokens),
+            temperature: self.temperature,
             stream: true,
             tools: openai_tools,
             tool_choice: if tools.is_empty() {

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -297,6 +297,8 @@ impl Provider for OllamaProvider {
 }
 
 impl OllamaProvider {
+    // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
+    #[allow(clippy::too_many_lines)]
     async fn complete_once(
         &self,
         messages: &[Message],

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -10,14 +10,6 @@ use crate::{
     provider::{Provider, StreamChunk, TokenStream, ToolDef},
 };
 
-/// Sampling temperature used when the caller does not specify one.
-///
-/// Ollama's own default is 0.8, which is tuned for open-ended chat. Local
-/// instruct models at that temperature drift out of the tool-call format —
-/// malformed JSON arguments and broken shell quoting. Agentic tool selection
-/// wants near-greedy decoding instead.
-pub const DEFAULT_TEMPERATURE: f32 = 0.2;
-
 /// How many times to re-request a turn that came back completely empty.
 ///
 /// Ollama returns a well-formed HTTP 200 with neither content nor tool calls at
@@ -30,7 +22,14 @@ pub struct OllamaProvider {
     model: String,
     base_url: String,
     max_tokens: u32,
-    temperature: f32,
+    /// `None` leaves sampling to the server's own default.
+    ///
+    /// Near-greedy decoding looks right for tool calling on priors, but
+    /// measured the opposite on `qwen2.5:3b-instruct`: at 0.2 the model locks
+    /// onto a wrong conclusion ("none of the provided functions can be used")
+    /// and re-emits identical tool calls instead of varying its retry. Left
+    /// unset unless the caller asks.
+    temperature: Option<f32>,
 }
 
 impl OllamaProvider {
@@ -43,14 +42,14 @@ impl OllamaProvider {
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
-            temperature: DEFAULT_TEMPERATURE,
+            temperature: None,
         }
     }
 
-    /// Override the sampling temperature.
+    /// Pin the sampling temperature instead of using the server default.
     #[must_use]
     pub fn with_temperature(mut self, temperature: f32) -> Self {
-        self.temperature = temperature;
+        self.temperature = Some(temperature);
         self
     }
 
@@ -158,7 +157,8 @@ struct OpenAiRequest<'a> {
     messages: Vec<OpenAiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
-    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiTool>>,

--- a/crates/core/src/toolcall_text.rs
+++ b/crates/core/src/toolcall_text.rs
@@ -1,0 +1,398 @@
+//! Recovery of tool calls that a model wrote as *text* instead of emitting on
+//! the native tool-call channel.
+//!
+//! Small local models (qwen2.5:3b class, served through Ollama) regularly slip
+//! out of the OpenAI `tool_calls` channel and write the call into the assistant
+//! message body instead — as a ```` ```json ```` fence, a `<tool_call>` tag, or a
+//! bare JSON object. A harness that only reads native `tool_calls` sees an
+//! ordinary end-of-turn and stops the run, so a recoverable formatting slip
+//! becomes a silent task failure.
+//!
+//! This module is pure and provider-agnostic: it turns text into candidate
+//! calls. Deciding whether to *execute* a recovered call is the agent loop's
+//! job.
+
+use serde_json::{Map, Value};
+
+/// A tool call recovered from assistant text.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedCall {
+    /// Tool name as written by the model.
+    pub name: String,
+    /// Arguments object (possibly repaired).
+    pub input: Value,
+    /// Which text encoding it was recovered from — useful for diagnostics.
+    pub format: CallFormat,
+}
+
+/// The text encoding a recovered call was written in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallFormat {
+    /// ```` ```tool ```` or ```` ```json ```` fenced block.
+    Fenced,
+    /// `<tool_call>…</tool_call>` tag.
+    Tag,
+    /// A bare JSON object sitting in the prose.
+    Bare,
+}
+
+/// Re-escape raw control characters that appear *inside* JSON string literals.
+///
+/// Models routinely emit a literal newline inside a string (common when the
+/// argument is a shell command or file body), which is invalid JSON.
+fn escape_control_chars_in_strings(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut in_string = false;
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if in_string && ch == '\\' {
+            out.push(ch);
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+            continue;
+        }
+        match ch {
+            '"' => {
+                in_string = !in_string;
+                out.push(ch);
+            }
+            '\n' if in_string => out.push_str("\\n"),
+            '\t' if in_string => out.push_str("\\t"),
+            '\r' if in_string => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Balance unclosed `{`/`[` by appending the missing closers.
+///
+/// Only counts brackets outside string literals, so a `}` inside a shell
+/// command doesn't throw the count off.
+fn close_unbalanced(text: &str) -> String {
+    let mut braces = 0i32;
+    let mut squares = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in text.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => braces += 1,
+            '}' => braces -= 1,
+            '[' => squares += 1,
+            ']' => squares -= 1,
+            _ => {}
+        }
+    }
+    let mut out = text.to_string();
+    // An unterminated string must be closed before its containing brackets.
+    if in_string {
+        out.push('"');
+    }
+    for _ in 0..squares.max(0) {
+        out.push(']');
+    }
+    for _ in 0..braces.max(0) {
+        out.push('}');
+    }
+    out
+}
+
+/// Best-effort JSON repair for near-miss model output.
+///
+/// Tries progressively more aggressive fixes and returns the first that parses.
+/// Returns `None` when the text cannot be salvaged into an object.
+#[must_use]
+pub fn repair_json(raw: &str) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // 1. As-is.
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(trimmed) {
+        return Some(v);
+    }
+    // 2. Re-escape raw control characters inside strings.
+    let mut fixed = escape_control_chars_in_strings(trimmed);
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&fixed) {
+        return Some(v);
+    }
+    // 3. Drop trailing commas before a closer.
+    fixed = fixed.replace(",}", "}").replace(",]", "]");
+    fixed = fixed.replace(", }", "}").replace(", ]", "]");
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&fixed) {
+        return Some(v);
+    }
+    // 4. Close unbalanced brackets — the truncation case (model hit max_tokens
+    //    or stopped mid-fence).
+    let closed = close_unbalanced(&fixed);
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&closed) {
+        return Some(v);
+    }
+    None
+}
+
+/// Pull the arguments object out of a decoded call, accepting the several key
+/// names models use interchangeably.
+fn extract_input(obj: &Map<String, Value>) -> Value {
+    for key in ["input", "arguments", "parameters", "args"] {
+        if let Some(v) = obj.get(key) {
+            // Some models double-encode the arguments as a JSON *string*.
+            if let Value::String(s) = v {
+                if let Some(parsed) = repair_json(s) {
+                    return parsed;
+                }
+            }
+            if v.is_object() {
+                return v.clone();
+            }
+        }
+    }
+    Value::Object(Map::new())
+}
+
+/// Build a call from a decoded JSON object, if it names a tool.
+fn call_from_value(v: &Value, format: CallFormat) -> Option<ParsedCall> {
+    let obj = v.as_object()?;
+    // Accept both the flat `{"name":…}` shape and OpenAI's `{"function":{…}}`.
+    let inner = obj
+        .get("function")
+        .and_then(Value::as_object)
+        .unwrap_or(obj);
+    let name = inner.get("name")?.as_str()?.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    Some(ParsedCall {
+        name,
+        input: extract_input(inner),
+        format,
+    })
+}
+
+/// Find each region between `open` and `close`, returning the inner slices.
+fn between<'a>(text: &'a str, open: &str, close: &str) -> Vec<&'a str> {
+    let mut found = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find(open) {
+        let after = &rest[start + open.len()..];
+        // An unterminated final block still carries a usable (truncated) payload.
+        let (body, next) = match after.find(close) {
+            Some(end) => (&after[..end], &after[end + close.len()..]),
+            None => (after, ""),
+        };
+        found.push(body);
+        if next.is_empty() {
+            break;
+        }
+        rest = next;
+    }
+    found
+}
+
+/// Extract the outermost balanced `{…}` regions of `text`, ignoring braces
+/// inside string literals.
+fn top_level_objects(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => {
+                if depth == 0 {
+                    start = i;
+                }
+                depth += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 && i >= start {
+                    if let Some(s) = text.get(start..=i) {
+                        out.push(s);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    // A truncated trailing object is still worth a repair attempt.
+    if depth > 0 {
+        if let Some(s) = text.get(start..) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Recover tool calls a model wrote into assistant text.
+///
+/// Checks, in order: ```` ``` ````-fenced blocks, `<tool_call>` tags, then bare
+/// JSON objects. Bare objects are only considered when neither of the explicit
+/// forms matched, since prose containing an unrelated JSON example would
+/// otherwise be misread as a call.
+#[must_use]
+pub fn parse_text_tool_calls(text: &str) -> Vec<ParsedCall> {
+    let mut calls = Vec::new();
+
+    // Fenced: ```tool / ```json / ```tool_call
+    for marker in ["```tool_call", "```tool", "```json"] {
+        for body in between(text, marker, "```") {
+            if let Some(v) = repair_json(body) {
+                if let Some(c) = call_from_value(&v, CallFormat::Fenced) {
+                    calls.push(c);
+                }
+            }
+        }
+        if !calls.is_empty() {
+            break;
+        }
+    }
+
+    // Tagged: <tool_call>…</tool_call>
+    for body in between(text, "<tool_call>", "</tool_call>") {
+        if let Some(v) = repair_json(body) {
+            if let Some(c) = call_from_value(&v, CallFormat::Tag) {
+                calls.push(c);
+            }
+        }
+    }
+
+    if calls.is_empty() {
+        for body in top_level_objects(text) {
+            if !body.contains("\"name\"") {
+                continue;
+            }
+            if let Some(v) = repair_json(body) {
+                if let Some(c) = call_from_value(&v, CallFormat::Bare) {
+                    calls.push(c);
+                }
+            }
+        }
+    }
+
+    calls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_text_tool_calls, repair_json, CallFormat};
+    use serde_json::json;
+
+    #[test]
+    fn parses_well_formed_fenced_call() {
+        let calls = parse_text_tool_calls("Let me look:\n```json\n{\"name\":\"bash\",\"input\":{\"command\":\"ls\"}}\n```\n");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "ls"}));
+        assert_eq!(calls[0].format, CallFormat::Fenced);
+    }
+
+    #[test]
+    fn parses_tool_call_tag() {
+        let calls =
+            parse_text_tool_calls("<tool_call>{\"name\": \"grep\", \"arguments\": {\"pattern\": \"fn main\"}}</tool_call>");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "grep");
+        assert_eq!(calls[0].input, json!({"pattern": "fn main"}));
+        assert_eq!(calls[0].format, CallFormat::Tag);
+    }
+
+    #[test]
+    fn parses_bare_json_object() {
+        let calls = parse_text_tool_calls("I will run {\"name\":\"bash\",\"parameters\":{\"command\":\"pwd\"}} now");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].format, CallFormat::Bare);
+    }
+
+    #[test]
+    fn recovers_truncated_fence() {
+        // The exact shape observed killing a baseline run: the model stopped
+        // mid-fence, leaving the object unterminated.
+        let calls = parse_text_tool_calls("Here we go:\n```json\n{\"name\": \"bash\", \"input\": {\"command\": \"git status\"");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "git status"}));
+    }
+
+    #[test]
+    fn repairs_literal_newline_inside_string() {
+        let v = repair_json("{\"command\": \"echo one\ntwo\"}").expect("should repair");
+        assert_eq!(v["command"], "echo one\ntwo");
+    }
+
+    #[test]
+    fn repairs_trailing_comma() {
+        let v = repair_json("{\"a\": 1,}").expect("should repair");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn accepts_openai_function_shape_with_stringified_args() {
+        let calls = parse_text_tool_calls(
+            "<tool_call>{\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}}</tool_call>",
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "ls"}));
+    }
+
+    #[test]
+    fn ignores_prose_without_calls() {
+        assert!(parse_text_tool_calls("The build passed and there are no TODOs.").is_empty());
+    }
+
+    #[test]
+    fn ignores_json_without_a_name_field() {
+        assert!(parse_text_tool_calls("Result was {\"count\": 3, \"ok\": true}").is_empty());
+    }
+
+    #[test]
+    fn does_not_treat_brace_inside_string_as_structure() {
+        let calls =
+            parse_text_tool_calls("{\"name\":\"bash\",\"input\":{\"command\":\"awk '{print $1}' f\"}}");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].input, json!({"command": "awk '{print $1}' f"}));
+    }
+
+    #[test]
+    fn multiple_tagged_calls_are_all_recovered() {
+        let calls = parse_text_tool_calls(
+            "<tool_call>{\"name\":\"bash\",\"input\":{\"command\":\"ls\"}}</tool_call>\
+             <tool_call>{\"name\":\"bash\",\"input\":{\"command\":\"pwd\"}}</tool_call>",
+        );
+        assert_eq!(calls.len(), 2);
+    }
+
+    #[test]
+    fn empty_text_yields_nothing() {
+        assert!(parse_text_tool_calls("").is_empty());
+        assert!(repair_json("   ").is_none());
+    }
+}

--- a/crates/core/src/toolcall_text.rs
+++ b/crates/core/src/toolcall_text.rs
@@ -2,7 +2,7 @@
 //! the native tool-call channel.
 //!
 //! Small local models (qwen2.5:3b class, served through Ollama) regularly slip
-//! out of the OpenAI `tool_calls` channel and write the call into the assistant
+//! out of the `OpenAI` `tool_calls` channel and write the call into the assistant
 //! message body instead — as a ```` ```json ```` fence, a `<tool_call>` tag, or a
 //! bare JSON object. A harness that only reads native `tool_calls` sees an
 //! ordinary end-of-turn and stops the run, so a recoverable formatting slip

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -10,6 +10,43 @@ use std::fmt::Write as _;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+/// Reject a path argument that the sandbox will not accept, telling the model
+/// what to send instead.
+///
+/// A bare refusal ("absolute paths are not allowed") is a dead end for a small
+/// local model: it has no way to derive the accepted form, so it either retries
+/// the same call or abandons the task and apologises in prose. Naming the
+/// working directory and, where it can be derived, the exact corrected path
+/// turns the rejection into something the model can act on in one step.
+fn reject_path(tool: &str, path: &str) -> ToolOutput {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd_display = cwd.display();
+
+    // If the path points inside the working directory, hand back the relative
+    // form directly — the model can retry verbatim.
+    if let Ok(rel) = Path::new(path).strip_prefix(&cwd) {
+        return ToolOutput::err(format!(
+            "`{tool}` takes paths relative to the working directory ({cwd_display}), \
+             not absolute paths. Retry with path=\"{}\".",
+            rel.display()
+        ));
+    }
+
+    ToolOutput::err(format!(
+        "`{tool}` takes paths relative to the working directory ({cwd_display}), \
+         not absolute paths like \"{path}\". Retry with a path relative to that \
+         directory, or use the `bash` tool if you need to reach outside it."
+    ))
+}
+
+/// Reject a `..` path, pointing at the escape hatch that does work.
+fn reject_traversal(tool: &str) -> ToolOutput {
+    ToolOutput::err(format!(
+        "`{tool}` does not allow `..` in paths. Retry with a path that stays \
+         inside the working directory, or use the `bash` tool for anything outside it."
+    ))
+}
+
 /// Echo tool - useful for testing the tool pipeline.
 pub struct EchoTool;
 
@@ -112,10 +149,10 @@ impl ToolHandler for GrepTool {
         // Security: validate path to prevent accessing arbitrary host files
         let p = std::path::Path::new(&path);
         if p.is_absolute() || path.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("grep", &path);
         }
         if p.components().any(|c| c == std::path::Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("grep");
         }
 
         let mut cmd = std::process::Command::new("grep");
@@ -236,10 +273,10 @@ impl ToolHandler for ReadFileTool {
 
         let p = Path::new(&path);
         if p.is_absolute() || path.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("read_file", &path);
         }
         if p.components().any(|c| c == Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("read_file");
         }
 
         match std::fs::read_to_string(&path) {
@@ -435,10 +472,10 @@ impl ToolHandler for WriteFileTool {
 
         let p = Path::new(&raw);
         if p.is_absolute() || raw.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("write_file", &raw);
         }
         if p.components().any(|c| c == Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("write_file");
         }
         let path_key = safe_edit_path_key(&raw);
         let file_exists = p.exists();
@@ -786,6 +823,53 @@ mod tests {
         let tool = ReadFileTool;
         let out = tool.call(json!({"path": "/etc/passwd"})).await;
         assert!(out.is_error);
+    }
+
+    /// A bare "not allowed" leaves a small model with nowhere to go — it retries
+    /// the same call or gives up in prose. The rejection must name the rule and
+    /// point at a way forward.
+    #[tokio::test]
+    async fn path_rejection_tells_the_model_what_to_do_instead() {
+        let out = ReadFileTool.call(json!({"path": "/etc/passwd"})).await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("relative"),
+            "rejection should name the accepted form: {}",
+            out.content
+        );
+        assert!(
+            out.content.contains("bash"),
+            "rejection should point at the escape hatch: {}",
+            out.content
+        );
+    }
+
+    /// When the path is inside the working directory the corrected form is
+    /// derivable, so hand it back verbatim — the model can retry in one step.
+    #[tokio::test]
+    async fn path_rejection_suggests_the_exact_relative_path() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let abs = cwd.join("Cargo.toml");
+        let out = ReadFileTool
+            .call(json!({ "path": abs.to_string_lossy() }))
+            .await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("Retry with path=\"Cargo.toml\""),
+            "expected an exact corrected path: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn traversal_rejection_is_actionable() {
+        let out = ReadFileTool.call(json!({"path": "../secret"})).await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("bash"),
+            "traversal rejection should point at the escape hatch: {}",
+            out.content
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this is

anvil has an `ollama` provider but was never tuned for the models people actually run locally. I scouted [`itayinbarr/little-coder`](https://github.com/itayinbarr/little-coder) — a harness built specifically around driving small local models — measured anvil against a ground-truth benchmark with `qwen2.5:3b-instruct`, and ported the mechanisms the measurements supported.

The premise, which the local fine-tune logs in `anvil-finetune-sessions/` already establish: **small local models fail agentic tasks on protocol, not on reasoning.** They slip out of the native tool-call channel, emit near-miss JSON, return empty completions, and give up when a tool rejects them. Those are harness-design problems, not model-capability problems.

## Measurement note first — a contamination bug in how anvil was being benchmarked

While measuring I found that `anvil run` resolves its episodic memory DB under `$HOME` and injects **up to 5 goal-matching past episodes into the system prompt** (`agent.rs::build_system_prompt_with_memory`). Repeated benchmark runs against the same goals therefore feed earlier answers to later runs.

I watched the same binary on the same 10 goals score **7/30, then 12/30, then 33/70** as the shared DB filled up. That is not model variance; it is the harness grading its own homework.

This affects any past benchmarking done by invoking `anvil run` in a loop — including the fine-tune eval (`eval_model.sh`), which ran exactly that way against a shared `~/.paperclip/harness/memory.db`. The 3/10-vs-1/10 numbers from that experiment should be treated as unverified for this reason, independent of the reasons already documented.

`anvil eval` is unaffected — it uses `MemoryDb::in_memory()`.

All numbers below use a fresh `$HOME` per run.

## Changes

Ordered by measured impact.

1. **Actionable path rejections** (`tools/builtin.rs`). `"absolute paths are not allowed"` is a dead end for a 3B: it has no way to derive the accepted form, so it retries the same call or apologises in prose. Rejections now name the working directory and, when derivable, the exact corrected path (`Retry with path="Cargo.toml"`). One shared helper, used by `read_file`, `grep` and `write_file`. This is little-coder's write-guard pattern — a refusal that directs the model to the action that works.

2. **Empty-completion retry** (`providers/ollama.rs`). Ollama returns HTTP 200 with neither content nor tool calls at a measurable rate on small local models. anvil read that as an ordinary end-of-turn and stopped. Now retried twice.

3. **Tool calls written as text are recovered** (`core/toolcall_text.rs`, wired in `agent.rs`). Models drop out of the native channel and emit ```` ```json ````, `<tool_call>`, or bare JSON in the message body. New pure module recovers these, with a JSON repair ladder handling raw newlines inside strings, trailing commas, and truncated tails. Bounded to 3 recoveries per run.

4. **Near-miss arguments on native calls are repaired** rather than silently dropped (they previously vanished with only a `warn!`, which reads to the loop as "the model chose not to call a tool").

5. **Explicit temperature, default 0.2**, exposed as `anvil run --temperature`. Ollama's default is 0.8, tuned for chat.

6. **Per-turn diagnostics** (`TurnDiag`, emitted in `--json-output`) so a run's failure mode can be measured rather than inferred by regexing prose.

## Honest results

See the PR discussion for the before/after table and the null results — notably that temperature made no measurable difference, and that the text-tool-call recovery never fired on this particular benchmark (it fires on the end-to-end task and throughout the fine-tune logs).

## Compatibility

Hosted-provider paths are untouched. Recovery only engages when a turn carries no native tool call; temperature is Ollama-only. Tests 78 → 97; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
