### PR TITLE
fix(tools): validate tool input property types

### DIFF
--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -634,6 +634,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registry_rejects_non_string_echo_message() {
+        let registry = crate::registry::ToolRegistry::new();
+        registry.register(EchoTool);
+
+        let out = registry.call("echo", json!({"message": 42})).await;
+
+        assert!(out.is_error);
+        assert!(
+            out.content
+                .contains("field `message` must be of type string"),
+            "expected schema type error, got: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_wrong_content_type_does_not_touch_files() {
+        let _scope = enter_test_fs_scope().await;
+        std::fs::write("existing.txt", "preserve me").expect("seed existing file");
+        let registry = crate::registry::ToolRegistry::new();
+        registry.register(WriteFileTool);
+
+        let create = registry
+            .call("write_file", json!({"path": "new.txt", "content": 42}))
+            .await;
+        let overwrite = registry
+            .call("write_file", json!({"path": "existing.txt", "content": 42}))
+            .await;
+
+        assert!(create.is_error);
+        assert!(overwrite.is_error);
+        assert!(!Path::new("new.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string("existing.txt").expect("read existing file"),
+            "preserve me"
+        );
+    }
+
+    #[tokio::test]
     async fn write_file_requires_read_before_overwrite() {
         let _scope = enter_test_fs_scope().await;
         std::fs::write("existing.txt", "before").expect("seed existing file");

--- a/crates/tools/src/registry.rs
+++ b/crates/tools/src/registry.rs
@@ -142,6 +142,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registry_rejects_wrong_input_type_before_dispatch() {
+        let registry = ToolRegistry::new();
+        registry.register(UpperCase);
+        let out = registry
+            .call("uppercase", serde_json::json!({"text": 42}))
+            .await;
+
+        assert!(out.is_error);
+        assert_eq!(
+            out.content,
+            "invalid input for uppercase: field `text` must be of type string"
+        );
+    }
+
+    #[tokio::test]
     async fn registry_unknown_tool() {
         let registry = ToolRegistry::new();
         let out = registry.call("nonexistent", serde_json::json!({})).await;

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -41,13 +41,18 @@ impl ToolSchema {
         }
     }
 
-    /// Validate an input value against this schema (basic required-field check).
+    /// Validate an input value against the schema shape used by built-in tools.
     ///
     /// # Errors
     ///
-    /// Returns `Err` with a human-readable message naming the first missing required field.
+    /// Returns `Err` with a human-readable message naming the first missing or
+    /// incorrectly typed field.
     pub fn validate(&self, input: &Value) -> Result<(), String> {
         let schema = &self.input_schema;
+        if let Some(expected) = schema.get("type").and_then(Value::as_str) {
+            validate_json_type(input, expected, "input")?;
+        }
+
         if let Some(required) = schema.get("required").and_then(|r| r.as_array()) {
             for field in required {
                 let key = field.as_str().unwrap_or("");
@@ -56,7 +61,39 @@ impl ToolSchema {
                 }
             }
         }
+
+        if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+            for (key, property_schema) in properties {
+                let Some(value) = input.get(key) else {
+                    continue;
+                };
+                let Some(expected) = property_schema.get("type").and_then(Value::as_str) else {
+                    continue;
+                };
+                validate_json_type(value, expected, &format!("field `{key}`"))?;
+            }
+        }
+
         Ok(())
+    }
+}
+
+fn validate_json_type(value: &Value, expected: &str, location: &str) -> Result<(), String> {
+    let matches = match expected {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
+    };
+
+    if matches {
+        Ok(())
+    } else {
+        Err(format!("{location} must be of type {expected}"))
     }
 }
 
@@ -71,5 +108,50 @@ mod tests {
             .validate(&serde_json::json!({"command": "ls"}))
             .is_ok());
         assert!(schema.validate(&serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn rejects_incorrect_required_field_type() {
+        let schema = ToolSchema::simple("echo", "Echo a message", &["message"]);
+        assert_eq!(
+            schema.validate(&serde_json::json!({"message": 42})),
+            Err("field `message` must be of type string".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_input() {
+        let schema = ToolSchema::simple("echo", "Echo a message", &["message"]);
+        assert_eq!(
+            schema.validate(&serde_json::json!("hello")),
+            Err("input must be of type object".to_string())
+        );
+    }
+
+    #[test]
+    fn validates_present_optional_fields_without_requiring_them() {
+        let schema = ToolSchema {
+            name: "grep".to_string(),
+            description: "Search files".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"}
+                },
+                "required": ["pattern"]
+            }),
+        };
+
+        assert!(schema
+            .validate(&serde_json::json!({"pattern": "needle"}))
+            .is_ok());
+        assert!(schema
+            .validate(&serde_json::json!({"pattern": "needle", "recursive": true}))
+            .is_ok());
+        assert_eq!(
+            schema.validate(&serde_json::json!({"pattern": "needle", "recursive": "yes"})),
+            Err("field `recursive` must be of type boolean".to_string())
+        );
     }
 }


### PR DESCRIPTION
## What changed

Validate the root JSON value and declared property types before `ToolRegistry` dispatches a built-in tool. Optional properties remain optional, while present values must match their schema type.

Regression coverage proves malformed `echo` input is rejected and numeric `write_file.content` cannot create or alter files.

## Why

The registry previously checked only required-field presence. Handlers then used permissive accessors and defaults, so `{ "content": 42 }` could be accepted as an empty string and `write_file` would report success after writing zero bytes.

## Developer impact

Invalid tool calls now fail early with an actionable field/type error instead of producing silent data loss or false success.

## Validation

- `cargo test` — 84 passed, 1 ignored
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
