### PR TITLE
fix(cli): reject unfinished subagent results

### DIFF
--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -528,8 +528,15 @@ impl Agent {
         let result = session
             .messages
             .last()
+            .filter(|message| message.role == Role::Assistant)
             .and_then(|m| m.text())
-            .unwrap_or("(sub-agent produced no output)")
+            .filter(|text| !text.trim().is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "sub-agent ended without a final assistant response \
+                     (it may have reached its iteration limit)"
+                )
+            })?
             .to_string();
 
         info!(
@@ -769,6 +776,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "context-aware result");
+    }
+
+    #[tokio::test]
+    async fn subagent_without_final_assistant_text_returns_error() {
+        let provider = Arc::new(ScriptedProvider::new(vec![tool_use_response(
+            "child-echo",
+            "echo",
+            serde_json::json!({"message": "unfinished"}),
+        )]));
+        let memory = make_memory().await;
+        let config = make_config(1);
+
+        let agent = Agent::new(provider, memory, config);
+        let result = agent.spawn_subagent("keep working", "").await;
+
+        assert!(result.is_err());
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("without a final assistant response"),
+            "unexpected error: {message}"
+        );
     }
 
     // -- New tests for memory recall and session continuity -------------------


### PR DESCRIPTION
## What changed

Require a delegated run to end with a non-empty assistant response before `spawn_subagent` reports success. A child that reaches its iteration cap immediately after a tool call now returns a clear error to the parent.

The project-mandated `SessionStatus::Done` behavior at the iteration cap remains unchanged.

## Root cause

`spawn_subagent` read `Message::text()` from the child's last message and replaced missing text with `"(sub-agent produced no output)"`. Tool-result messages have no text representation, so budget exhaustion was converted into a successful placeholder.

## Developer impact

Parent agents can now distinguish completed delegation from unfinished work and react or report the failure honestly.

## Validation

- deterministic scripted-provider regression
- `cargo test` — 79 passed, 1 ignored
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
