### PR TITLE
fix(cli): bound Ollama request waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ ollama pull qwen2.5:3b-instruct
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Say hello in exactly three words."
 ```
 
+Ollama requests time out after 60 seconds by default. For a large model that needs longer to load,
+pass `--ollama-timeout-secs 300` or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
+
 ### Choosing a local model
 
 Tool-calling ability matters far more than speed here.

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use clap::Args;
 use harness_core::{
     config::Config,
     provider::Provider,
+    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
     providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
 };
 use harness_memory::MemoryDb;
@@ -12,6 +13,13 @@ use indicatif::ProgressBar;
 
 use crate::agent::{Agent, RunOptions, UiHook};
 use crate::ui;
+
+fn parse_positive_timeout(value: &str) -> Result<u64, String> {
+    match value.parse::<u64>() {
+        Ok(seconds) if seconds > 0 => Ok(seconds),
+        _ => Err("timeout must be a positive number of seconds".to_string()),
+    }
+}
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -26,6 +34,15 @@ pub struct RunArgs {
     /// Model identifier override (e.g. "gemma4:e2b")
     #[arg(long, env = "HARNESS_MODEL")]
     pub model: Option<String>,
+
+    /// Maximum seconds to wait for each Ollama request
+    #[arg(
+        long,
+        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
+        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
+        value_parser = parse_positive_timeout
+    )]
+    pub ollama_timeout_secs: u64,
 
     /// Stream response tokens to stdout as they arrive
     #[arg(long)]
@@ -271,11 +288,17 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
                 .base_url
                 .as_deref()
                 .unwrap_or("http://localhost:11434");
-            tracing::info!(model = %model, base_url = %base_url, "using OllamaProvider");
-            Arc::new(OllamaProvider::new(
+            tracing::info!(
+                model = %model,
+                base_url = %base_url,
+                timeout_secs = args.ollama_timeout_secs,
+                "using OllamaProvider"
+            );
+            Arc::new(OllamaProvider::with_timeout(
                 base_url,
                 &model,
                 config.provider.max_tokens,
+                Duration::from_secs(args.ollama_timeout_secs),
             ))
         }
         _ => Arc::new(
@@ -368,4 +391,16 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_positive_timeout;
+
+    #[test]
+    fn ollama_timeout_must_be_positive() {
+        assert_eq!(parse_positive_timeout("45"), Ok(45));
+        assert!(parse_positive_timeout("0").is_err());
+        assert!(parse_positive_timeout("not-a-number").is_err());
+    }
 }

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client;
@@ -15,18 +17,54 @@ pub struct OllamaProvider {
     model: String,
     base_url: String,
     max_tokens: u32,
+    request_timeout: Duration,
+}
+
+pub const DEFAULT_OLLAMA_TIMEOUT_SECS: u64 = 60;
+
+fn timeout_label(timeout: Duration) -> String {
+    if timeout.as_secs() > 0 {
+        format!("{}s", timeout.as_secs())
+    } else {
+        format!("{}ms", timeout.as_millis())
+    }
+}
+
+fn ollama_request_error(error: &reqwest::Error, timeout: Duration, endpoint: &str) -> HarnessError {
+    if error.is_timeout() {
+        HarnessError::Provider(format!(
+            "Ollama request to {endpoint} timed out after {}. \
+             The model may still be loading; retry, choose a smaller model, or increase \
+             --ollama-timeout-secs (ANVIL_OLLAMA_TIMEOUT_SECS).",
+            timeout_label(timeout)
+        ))
+    } else {
+        HarnessError::Provider(error.to_string())
+    }
 }
 
 impl OllamaProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>, max_tokens: u32) -> Self {
+        Self::with_timeout(
+            base_url,
+            model,
+            max_tokens,
+            Duration::from_secs(DEFAULT_OLLAMA_TIMEOUT_SECS),
+        )
+    }
+
+    pub fn with_timeout(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+        request_timeout: Duration,
+    ) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
-                .build()
-                .unwrap_or_else(|_| Client::new()),
+            client: Client::new(),
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
+            request_timeout,
         }
     }
 
@@ -35,6 +73,10 @@ impl OllamaProvider {
             "{}/v1/chat/completions",
             self.base_url.trim_end_matches('/')
         )
+    }
+
+    fn request(&self, endpoint: &str) -> reqwest::RequestBuilder {
+        self.client.post(endpoint).timeout(self.request_timeout)
     }
 
     fn build_openai_messages(messages: &[Message]) -> Vec<OpenAiMessage> {
@@ -269,29 +311,32 @@ impl Provider for OllamaProvider {
             },
         };
 
-        debug!(model = %self.model, url = %self.endpoint(), "sending request to Ollama (OpenAI-compatible)");
+        let endpoint = self.endpoint();
+        debug!(model = %self.model, url = %endpoint, "sending request to Ollama (OpenAI-compatible)");
 
         let resp = self
-            .client
-            .post(self.endpoint())
+            .request(&endpoint)
             .json(&body)
             .send()
             .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+            .map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
 
         let status = resp.status();
         if !status.is_success() {
-            let raw = resp.text().await.unwrap_or_default();
+            let raw = resp.text().await.map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
             return Err(HarnessError::Api {
                 status: status.as_u16(),
                 body: raw,
             });
         }
 
-        let api_resp: OpenAiResponse = resp
-            .json()
-            .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+        let api_resp: OpenAiResponse = resp.json().await.map_err(|error| {
+            ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+        })?;
 
         let choice = api_resp
             .choices
@@ -390,17 +435,21 @@ impl Provider for OllamaProvider {
             },
         };
 
+        let endpoint = self.endpoint();
         let resp = self
-            .client
-            .post(self.endpoint())
+            .request(&endpoint)
             .json(&body)
             .send()
             .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+            .map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
 
         let status = resp.status();
         if !status.is_success() {
-            let raw = resp.text().await.unwrap_or_default();
+            let raw = resp.text().await.map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
             return Err(HarnessError::Api {
                 status: status.as_u16(),
                 body: raw,
@@ -409,6 +458,7 @@ impl Provider for OllamaProvider {
 
         let (tx, rx) = futures::channel::mpsc::channel::<Result<StreamChunk>>(64);
         let mut byte_stream = resp.bytes_stream();
+        let request_timeout = self.request_timeout;
 
         tokio::spawn(async move {
             let mut tx = tx;
@@ -417,7 +467,11 @@ impl Provider for OllamaProvider {
             while let Some(item) = byte_stream.next().await {
                 match item {
                     Err(e) => {
-                        let _ = tx.try_send(Err(HarnessError::Provider(e.to_string())));
+                        let _ = tx.try_send(Err(ollama_request_error(
+                            &e,
+                            request_timeout,
+                            endpoint.as_str(),
+                        )));
                         return;
                     }
                     Ok(bytes) => {
@@ -476,5 +530,77 @@ impl Provider for OllamaProvider {
         });
 
         Ok(Box::pin(rx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    async fn spawn_stalled_server(send_headers: bool) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = socket.read(&mut request).await;
+            if send_headers {
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\n\
+                          Content-Type: text/event-stream\r\n\
+                          Transfer-Encoding: chunked\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            }
+            std::future::pending::<()>().await;
+        });
+        (format!("http://{address}"), task)
+    }
+
+    #[tokio::test]
+    async fn non_streaming_request_timeout_is_bounded_and_actionable() {
+        let (base_url, server) = spawn_stalled_server(false).await;
+        let provider =
+            OllamaProvider::with_timeout(base_url, "test-model", 128, Duration::from_millis(100));
+
+        let error = provider
+            .complete(&[Message::user("hello")])
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+
+        assert!(error.contains("timed out after 100ms"), "{error}");
+        assert!(error.contains("--ollama-timeout-secs"), "{error}");
+        assert!(error.contains("model may still be loading"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn streaming_body_timeout_is_bounded_and_actionable() {
+        let (base_url, server) = spawn_stalled_server(true).await;
+        let provider =
+            OllamaProvider::with_timeout(base_url, "test-model", 128, Duration::from_millis(100));
+
+        let mut stream = provider
+            .stream(&[Message::user("hello")])
+            .await
+            .expect("response headers should arrive before the timeout");
+        let error = stream
+            .next()
+            .await
+            .expect("stream should report the timeout")
+            .unwrap_err()
+            .to_string();
+        server.abort();
+
+        assert!(error.contains("timed out after 100ms"), "{error}");
+        assert!(error.contains("--ollama-timeout-secs"), "{error}");
     }
 }


### PR DESCRIPTION
## What changed

- add `--ollama-timeout-secs` with `ANVIL_OLLAMA_TIMEOUT_SECS` support and positive-value validation
- preserve the existing 60-second default
- apply the bound to both streaming and non-streaming request lifecycles
- replace opaque timeout failures with actionable model-loading guidance
- remove the fallible client-builder path that could silently fall back to an unbounded client

## Root cause

Ollama's timeout was hidden inside provider construction. Users remained on the `thinking` spinner with no visible bound or remediation, and a client-builder failure could replace the bounded client with `Client::new()`.

This is especially painful on cold loads: the reported `qwen3.6:latest` model is 23 GB locally and was not resident in `ollama ps`.

## User impact

A stalled or cold-loading local model now exits within a documented bound and explains how to retry, choose a smaller model, or raise the timeout.

## Validation

- stalled-server regressions for pre-header and streaming-body timeouts
- CLI parser/help validation, including zero rejection
- `cargo test` — 81 passed, 1 ignored
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
