### PR TITLE
feat(cli): add interactive chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ ollama pull qwen2.5:3b-instruct
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Say hello in exactly three words."
 ```
 
-Ollama requests time out after 60 seconds by default. For a large model that needs longer to load,
-pass `--ollama-timeout-secs 300` or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
+Ollama requests time out after 60 seconds by default. Both `run` and `chat` accept
+`--ollama-timeout-secs 300`, or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
 
 ### Choosing a local model
 
@@ -75,6 +75,14 @@ No LLM at all? The `echo` provider mirrors input back and is what the test suite
 ```bash
 anvil run --provider echo --goal "hello"
 ```
+
+Want to keep talking without starting a new command for every prompt?
+
+```bash
+anvil chat --provider echo --session myproject
+```
+
+Chat keeps every prompt in the same named session. Type `/exit` or press Ctrl-D to leave.
 
 ---
 
@@ -105,6 +113,9 @@ Adding a provider: implement one async trait in `crates/core/src/providers/`.
 ```bash
 # Run an agent session
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Summarise the current directory"
+
+# Start an interactive chat; omit --session to generate a resumable session name
+anvil chat --provider ollama --model qwen2.5:3b-instruct --session myproject
 
 # Stream tokens as they arrive
 anvil run --provider echo --goal "hello" --stream

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,0 +1,159 @@
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+
+use clap::Args;
+use harness_core::config::Config;
+use harness_memory::MemoryDb;
+use uuid::Uuid;
+
+use crate::agent::{Agent, RunOptions, UiHook};
+use crate::commands::{provider, run::CliHook};
+use crate::ui;
+
+#[derive(Args)]
+pub struct ChatArgs {
+    #[command(flatten)]
+    provider: provider::ProviderArgs,
+
+    /// Named session to resume. A new chat session name is generated when omitted
+    #[arg(long)]
+    pub session: Option<String>,
+
+    /// Maximum agent iterations for each prompt (default: 10). Set to 0 for unlimited
+    #[arg(long, default_value_t = 10)]
+    pub max_iterations: usize,
+}
+
+pub async fn execute(args: ChatArgs) -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let resolved = provider::resolve(&config, &args.provider)?;
+    let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
+    let session_name = args
+        .session
+        .unwrap_or_else(|| format!("chat-{}", Uuid::new_v4()));
+    let hook = CliHook::new();
+    let agent = Agent::new(Arc::clone(&resolved.provider), Arc::clone(&memory), config)
+        .with_hook(Arc::clone(&hook) as Arc<dyn UiHook>);
+
+    ui::print_banner();
+    ui::print_session_header(&session_name, &resolved.model, &resolved.backend);
+    eprintln!("  Interactive chat session: {session_name}");
+    eprintln!("  Type /exit or press Ctrl-D to leave.\n");
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = stdin.lock();
+    let mut writer = stdout.lock();
+    run_chat_loop(
+        &agent,
+        &session_name,
+        args.max_iterations,
+        &mut reader,
+        &mut writer,
+    )
+    .await
+}
+
+async fn run_chat_loop<R: BufRead, W: Write>(
+    agent: &Agent,
+    session_name: &str,
+    max_iterations: usize,
+    reader: &mut R,
+    writer: &mut W,
+) -> anyhow::Result<()> {
+    let max_iterations = if max_iterations == 0 {
+        usize::MAX
+    } else {
+        max_iterations
+    };
+    let options = RunOptions {
+        session_name: Some(session_name.to_string()),
+        max_iterations: Some(max_iterations),
+    };
+
+    loop {
+        write!(writer, "you> ")?;
+        writer.flush()?;
+
+        let mut input = String::new();
+        if reader.read_line(&mut input)? == 0 {
+            writeln!(writer, "\nGoodbye.")?;
+            break;
+        }
+
+        let prompt = input.trim();
+        if prompt == "/exit" {
+            writeln!(writer, "Goodbye.")?;
+            break;
+        }
+        if prompt.is_empty() {
+            continue;
+        }
+
+        let session = agent.run_with_options(prompt, options.clone()).await?;
+        let response = session
+            .messages
+            .last()
+            .and_then(|message| message.text())
+            .unwrap_or("(no response)");
+        writeln!(writer, "anvil> {response}")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use harness_core::provider::EchoProvider;
+
+    use super::*;
+
+    async fn test_agent() -> (Agent, Arc<MemoryDb>) {
+        let memory = Arc::new(MemoryDb::in_memory().await.unwrap());
+        let agent = Agent::new(
+            Arc::new(EchoProvider),
+            Arc::clone(&memory),
+            Config::default(),
+        );
+        (agent, memory)
+    }
+
+    #[tokio::test]
+    async fn processes_multiple_prompts_in_one_named_session() {
+        let (agent, memory) = test_agent().await;
+        let mut input = Cursor::new(b"first prompt\nsecond prompt\n/exit\n");
+        let mut output = Vec::new();
+
+        run_chat_loop(&agent, "test-chat", 10, &mut input, &mut output)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("anvil> echo: first prompt"));
+        assert!(output.contains("anvil> echo: second prompt"));
+        assert!(output.ends_with("Goodbye.\n"));
+
+        let history = memory.recent_by_name("test-chat", 10).await.unwrap();
+        assert_eq!(history.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn eof_exits_cleanly_without_running_the_agent() {
+        let (agent, memory) = test_agent().await;
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let mut output = Vec::new();
+
+        run_chat_loop(&agent, "empty-chat", 10, &mut input, &mut output)
+            .await
+            .unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap(), "you> \nGoodbye.\n");
+        assert!(memory
+            .recent_by_name("empty-chat", 10)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod auth;
+pub mod chat;
 pub mod config;
 pub mod eval;
 pub mod memory;
+pub(crate) mod provider;
 pub mod run;

--- a/crates/cli/src/commands/provider.rs
+++ b/crates/cli/src/commands/provider.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Args;
+use harness_core::{
+    config::Config,
+    provider::Provider,
+    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
+    providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
+};
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct ProviderArgs {
+    /// Provider backend override (claude, claude-code, cc, ollama, echo)
+    #[arg(long, env = "HARNESS_PROVIDER")]
+    pub(crate) provider: Option<String>,
+
+    /// Model identifier override (e.g. "gemma4:e2b")
+    #[arg(long, env = "HARNESS_MODEL")]
+    pub(crate) model: Option<String>,
+
+    /// Maximum seconds to wait for each Ollama request
+    #[arg(
+        long,
+        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
+        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
+        value_parser = parse_positive_timeout
+    )]
+    pub(crate) ollama_timeout_secs: u64,
+}
+
+pub(crate) struct ResolvedProvider {
+    pub(crate) backend: String,
+    pub(crate) model: String,
+    pub(crate) provider: Arc<dyn Provider>,
+}
+
+pub(crate) fn resolve(config: &Config, args: &ProviderArgs) -> anyhow::Result<ResolvedProvider> {
+    let provider_override = args.provider.as_deref();
+    let mut backend = provider_override
+        .unwrap_or(&config.provider.backend)
+        .to_string();
+    let model = args
+        .model
+        .as_deref()
+        .unwrap_or(&config.provider.model)
+        .to_string();
+
+    // Auto-detect ollama when no provider is explicitly specified and the model
+    // doesn't look like a known Claude or OpenAI model.
+    if provider_override.is_none()
+        && !model.starts_with("claude")
+        && !model.starts_with("anthropic/")
+        && !model.starts_with("gpt-")
+        && !model.starts_with("openai/")
+    {
+        tracing::info!(model = %model, "auto-detecting ollama provider from model name");
+        backend = "ollama".to_string();
+    }
+
+    let provider: Arc<dyn Provider> = match backend.as_str() {
+        "echo" => {
+            tracing::info!("using echo provider (no LLM calls)");
+            Arc::new(harness_core::provider::EchoProvider)
+        }
+        "claude-code" | "cc" => {
+            tracing::info!(model = %model, "using ClaudeCodeProvider (subprocess)");
+            Arc::new(ClaudeCodeProvider::new(&model))
+        }
+        "ollama" => build_ollama_provider(config, &model, args.ollama_timeout_secs),
+        _ => Arc::new(
+            ClaudeProvider::from_env(&model, config.provider.max_tokens)
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+        ),
+    };
+
+    Ok(ResolvedProvider {
+        backend,
+        model,
+        provider,
+    })
+}
+
+fn build_ollama_provider(config: &Config, model: &str, timeout_secs: u64) -> Arc<dyn Provider> {
+    let base_url = config
+        .provider
+        .base_url
+        .as_deref()
+        .unwrap_or("http://localhost:11434");
+    tracing::info!(model, base_url, timeout_secs, "using OllamaProvider");
+    Arc::new(OllamaProvider::with_timeout(
+        base_url,
+        model,
+        config.provider.max_tokens,
+        Duration::from_secs(timeout_secs),
+    ))
+}
+
+fn parse_positive_timeout(value: &str) -> Result<u64, String> {
+    match value.parse::<u64>() {
+        Ok(seconds) if seconds > 0 => Ok(seconds),
+        _ => Err("timeout must be a positive number of seconds".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_args(provider: Option<&str>, model: Option<&str>) -> ProviderArgs {
+        ProviderArgs {
+            provider: provider.map(str::to_string),
+            model: model.map(str::to_string),
+            ollama_timeout_secs: DEFAULT_OLLAMA_TIMEOUT_SECS,
+        }
+    }
+
+    #[test]
+    fn echo_provider_can_be_selected_without_credentials() {
+        let config = Config::default();
+        let resolved = resolve(&config, &provider_args(Some("echo"), Some("test-model"))).unwrap();
+
+        assert_eq!(resolved.backend, "echo");
+        assert_eq!(resolved.model, "test-model");
+        assert_eq!(resolved.provider.name(), "echo");
+    }
+
+    #[test]
+    fn local_model_auto_selects_ollama_without_provider_override() {
+        let config = Config::default();
+        let resolved = resolve(&config, &provider_args(None, Some("qwen2.5:3b"))).unwrap();
+
+        assert_eq!(resolved.backend, "ollama");
+        assert_eq!(resolved.model, "qwen2.5:3b");
+    }
+
+    #[test]
+    fn ollama_timeout_must_be_positive() {
+        assert_eq!(parse_positive_timeout("45"), Ok(45));
+        assert!(parse_positive_timeout("0").is_err());
+        assert!(parse_positive_timeout("not-a-number").is_err());
+    }
+}

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,25 +1,14 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use clap::Args;
-use harness_core::{
-    config::Config,
-    provider::Provider,
-    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
-    providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
-};
+use harness_core::config::Config;
 use harness_memory::MemoryDb;
 use indicatif::ProgressBar;
 
 use crate::agent::{Agent, RunOptions, UiHook};
+use crate::commands::provider;
 use crate::ui;
-
-fn parse_positive_timeout(value: &str) -> Result<u64, String> {
-    match value.parse::<u64>() {
-        Ok(seconds) if seconds > 0 => Ok(seconds),
-        _ => Err("timeout must be a positive number of seconds".to_string()),
-    }
-}
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -27,22 +16,8 @@ pub struct RunArgs {
     #[arg(short, long)]
     pub goal: String,
 
-    /// Provider backend override (claude, claude-code, cc, ollama, echo)
-    #[arg(long, env = "HARNESS_PROVIDER")]
-    pub provider: Option<String>,
-
-    /// Model identifier override (e.g. "gemma4:e2b")
-    #[arg(long, env = "HARNESS_MODEL")]
-    pub model: Option<String>,
-
-    /// Maximum seconds to wait for each Ollama request
-    #[arg(
-        long,
-        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
-        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
-        value_parser = parse_positive_timeout
-    )]
-    pub ollama_timeout_secs: u64,
+    #[command(flatten)]
+    provider: provider::ProviderArgs,
 
     /// Stream response tokens to stdout as they arrive
     #[arg(long)]
@@ -74,12 +49,12 @@ pub struct RunArgs {
 // ── Terminal (coloured) hook ──────────────────────────────────────────────────
 
 /// CLI UI hook: drives the spinner and prints tool call/result lines.
-struct CliHook {
+pub(crate) struct CliHook {
     spinner: std::sync::Mutex<Option<ProgressBar>>,
 }
 
 impl CliHook {
-    fn new() -> Arc<Self> {
+    pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             spinner: std::sync::Mutex::new(None),
         })
@@ -248,64 +223,10 @@ impl UiHook for JsonHook {
 #[allow(clippy::too_many_lines)]
 pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     let config = Config::load()?;
-
-    let backend_override = args.provider.as_deref();
-    let mut backend = args
-        .provider
-        .as_deref()
-        .unwrap_or(&config.provider.backend)
-        .to_string();
-    let model = args
-        .model
-        .as_deref()
-        .unwrap_or(&config.provider.model)
-        .to_string();
-
-    // Auto-detect ollama when no provider is explicitly specified and the model
-    // doesn't look like a known Claude or OpenAI model.
-    if backend_override.is_none()
-        && !model.starts_with("claude")
-        && !model.starts_with("anthropic/")
-        && !model.starts_with("gpt-")
-        && !model.starts_with("openai/")
-    {
-        tracing::info!(model = %model, "auto-detecting ollama provider from model name");
-        backend = "ollama".to_string();
-    }
-
-    let provider: Arc<dyn Provider> = match backend.as_str() {
-        "echo" => {
-            tracing::info!("using echo provider (no LLM calls)");
-            Arc::new(harness_core::provider::EchoProvider)
-        }
-        "claude-code" | "cc" => {
-            tracing::info!(model = %model, "using ClaudeCodeProvider (subprocess)");
-            Arc::new(ClaudeCodeProvider::new(&model))
-        }
-        "ollama" => {
-            let base_url = config
-                .provider
-                .base_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434");
-            tracing::info!(
-                model = %model,
-                base_url = %base_url,
-                timeout_secs = args.ollama_timeout_secs,
-                "using OllamaProvider"
-            );
-            Arc::new(OllamaProvider::with_timeout(
-                base_url,
-                &model,
-                config.provider.max_tokens,
-                Duration::from_secs(args.ollama_timeout_secs),
-            ))
-        }
-        _ => Arc::new(
-            ClaudeProvider::from_env(&model, config.provider.max_tokens)
-                .map_err(|e| anyhow::anyhow!("{e}"))?,
-        ),
-    };
+    let resolved = provider::resolve(&config, &args.provider)?;
+    let backend = resolved.backend;
+    let model = resolved.model;
+    let provider = resolved.provider;
 
     let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
 
@@ -391,16 +312,4 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_positive_timeout;
-
-    #[test]
-    fn ollama_timeout_must_be_positive() {
-        assert_eq!(parse_positive_timeout("45"), Ok(45));
-        assert!(parse_positive_timeout("0").is_err());
-        assert!(parse_positive_timeout("not-a-number").is_err());
-    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,8 @@ struct Cli {
 enum Commands {
     /// Run an agent turn toward a goal
     Run(commands::run::RunArgs),
+    /// Start an interactive multi-turn chat session
+    Chat(commands::chat::ChatArgs),
     /// Show current configuration
     Config(commands::config::ConfigArgs),
     /// Manage and inspect memory
@@ -55,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Run(args) => commands::run::execute(args).await,
+        Commands::Chat(args) => commands::chat::execute(args).await,
         Commands::Config(args) => commands::config::execute(args).await,
         Commands::Memory(args) => commands::memory::execute(args).await,
         Commands::Eval(args) => commands::eval::execute(args).await,


### PR DESCRIPTION
## What changed

Add a discoverable `anvil chat` subcommand for repeated prompts in one resumable named session.

- shared provider/model/Ollama-timeout options with `anvil run`
- generated session name when `--session` is omitted
- `/exit` and EOF terminate cleanly
- buffered loop is tested with `EchoProvider` and in-memory memory
- provider construction is centralized so run/chat behavior cannot drift
- README and CLI help include interactive examples

## Why

The CLI only accepted one-shot `--goal` invocations. Continuing a conversation required repeatedly invoking `run` and manually preserving a session name, with no prompt loop or clear exit UX.

## User impact

Users can now run:

```bash
anvil chat --provider ollama --model qwen3.6:latest --session myproject
```

and keep conversing until `/exit` or Ctrl-D. Both run and chat expose the bounded Ollama wait introduced by the parent PR.

## Validation

- multi-prompt named-session and EOF regressions using EchoProvider/in-memory DB
- both run/chat help surfaces verified
- `cargo test` — 85 passed, 1 ignored
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- parent-relative `git diff --check`

## Stack

This PR intentionally targets `fix/ollama-bounded-wait` so shared provider setup is reviewed without conflicts. Retarget to `main` after #91 lands.
