### PR TITLE
release: ship PRs #88-#93 (local-model reliability, tool validation, chat mode)

### DIFF
--- a/FEEDBACK_REPORT.md
+++ b/FEEDBACK_REPORT.md
@@ -1,0 +1,147 @@
+# Anvil Alignment Feedback Report
+
+## Declared intent
+
+Anvil is a self-bootstrapping Rust agent harness for developers and coding
+agents. A user should be able to submit a goal through the CLI, have the
+harness plan and execute bounded tool-using turns (including delegated work),
+persist the resulting episode history, and inspect the run afterward.
+
+For this dogfood pass, alignment means:
+
+- the documented CLI can complete a CI-safe run without real API calls;
+- tool contracts reject invalid inputs instead of reporting false success;
+- delegated work reports an honest result when it cannot finish;
+- memory preserves a usable chronological history;
+- machine-readable output identifies what actually ran; and
+- fixes are small, tested, and independently reviewable.
+
+## Iteration 1 — 2026-07-28
+
+### Inventory
+
+Shipping CLI commands:
+
+- `anvil run`
+- `anvil config`
+- `anvil memory`
+- `anvil eval`
+- `anvil auth`
+
+Shipping agent surfaces include the bounded turn loop, built-in file/search
+and shell tools, `spawn_subagent`, and the skill-library tools
+`list_skills`, `read_skill`, `save_skill`, and `refine_skill`.
+
+The `evolution`, `github`, and `paperclip` crates build as workspace members
+but are not wired into the shipped binary. PR #88 already covers Ollama
+small-model protocol recovery and benchmark-memory contamination, so that
+area was excluded from this pass.
+
+### Exercises and wins
+
+- `anvil eval --provider echo` completed a JSONL case without credentials.
+- A uniquely named `anvil run --provider echo` session completed and was
+  readable through `anvil memory recent`.
+- Normal relative-path file reads/writes, file grep, recursive directory grep,
+  shell execution, and skill save/list flows worked.
+- Existing focused suites passed: 31 `harness-tools` tests, subagent tests,
+  max-iteration tests, and skill-library tests.
+- The two `harness-paperclip` failures seen in the managed sandbox were
+  environmental socket restrictions; all paperclip tests passed when rerun
+  outside that restriction.
+
+### Gaps
+
+| # | Gap | Severity | Evidence |
+|---|---|---|---|
+| 1 | Tool schemas accept values with the wrong JSON type, allowing handlers to silently substitute defaults. | HIGH | A registry call to `write_file` with numeric `content` returned success and created a zero-byte file. `crates/tools/src/schema.rs` checked required-field presence but not declared property types. |
+| 2 | A subagent that reaches its iteration cap immediately after a tool call is reported as successful placeholder output. | HIGH | `spawn_subagent` converted a child whose last message was a tool result into `ToolOutput::ok("(sub-agent produced no output)")` in `crates/cli/src/agent.rs`. |
+| 3 | Named-session history is persisted in assistant/user order, and a limited query selects the oldest rather than newest window. | HIGH | Two echo runs followed by `anvil memory recent <name> --limit 2` returned the first exchange; inserts in `crates/cli/src/agent.rs` are assistant-first and `crates/memory/src/db.rs` applies `ORDER BY created_at ASC LIMIT`. |
+| 4 | `anvil eval` cannot use the default `claude-code` backend. | HIGH | With config reporting `claude-code`, eval fell through to the direct Claude path and requested `ANTHROPIC_API_KEY`; `--provider echo` succeeded. |
+| 5 | A typoed `anvil run --provider` value silently falls through to direct Claude. | MEDIUM | `--provider not-a-provider` produced an unrelated Anthropic credential error because the provider match uses direct Claude as its wildcard arm. |
+| 6 | JSON result events report the configured model rather than the provider that actually ran. | MEDIUM | An echo run emitted `"model":"claude-sonnet-4-5"` in its result event. |
+| 7 | `auth status` contradicts `config --check` for keyless/delegated backends. | MEDIUM | With `claude-code` configured, config check exited successfully while auth status reported no credentials and exited 1. |
+| 8 | Directory grep requires callers to discover and set `recursive: true` even though the tool advertises file-or-directory input. | MEDIUM | `grep` on `.` failed with “Is a directory”; the same call with `recursive:true` succeeded. |
+| 9 | Skill metadata helpers rewrite body lines that merely look like frontmatter fields. | MEDIUM | `read_skill`/`refine_skill` scan the whole Markdown file for trimmed `uses:` and `version:` lines in `crates/tools/src/builtin.rs`. |
+
+### Actions
+
+- Selected gap 1 for a focused tool-schema validation fix with regression tests.
+- Selected gap 2 for a focused subagent-result fix while preserving the
+  project-mandated `SessionStatus::Done` behavior at the iteration cap.
+- Deferred gaps 3, 4, and 7 because concurrent local work already contains a
+  CLI-fixes commit touching the same memory/eval/auth files.
+- Deferred gaps 5, 6, 8, and 9 to keep this iteration independently
+  reviewable and avoid overlap with active PRs.
+
+### Queued
+
+1. Re-dogfood named-session chronology after the concurrent CLI work lands.
+2. Reject unknown provider identifiers and report the effective provider/model
+   in structured output.
+3. Make directory grep ergonomic by default without changing explicit
+   non-recursive behavior.
+4. Restrict skill metadata parsing and updates to YAML frontmatter.
+5. Decide whether `--max-iterations` is a per-agent or shared delegation-tree
+   budget, then encode that contract in tests and CLI help.
+
+## Iteration 2 — 2026-07-28
+
+### User feedback
+
+Direct dogfood feedback superseded the queue:
+
+- `cargo install --path crates/cli` failed because a newly added
+  `compact_system_prompt` field was missing from an `AgentConfig` initializer,
+  so no `anvil` executable was installed.
+- After that initializer landed in concurrent local work, Cargo installed to
+  `~/.cargo/bin`, which was not on the interactive shell path.
+- A run with `qwen3.6:latest` remained on `thinking` with no visible bound or
+  loading guidance.
+- The CLI had no interactive chat surface; every interaction required a new
+  `anvil run --goal`.
+
+### Evidence and scoring
+
+| # | Gap | Severity | Evidence |
+|---|---|---|---|
+| 10 | Ollama waits are not configurable from the CLI and timeout failures do not explain cold model loading. | HIGH | `qwen3.6:latest` is a 23 GB local model and was not resident in `ollama ps`; the CLI displayed only `thinking`. Provider construction hid the request timeout and had a fallible path to an unbounded client. |
+| 11 | No interactive multi-turn chat command exists. | HIGH | `anvil --help` exposed only one-shot `run --goal`; user feedback explicitly requested a persistent chat mode. |
+| 12 | Cargo's default install location is not necessarily on the user's shell path. | MEDIUM | `cargo install` placed the binary in `~/.cargo/bin`, while the interactive shell path included `~/.local/bin` but not `~/.cargo/bin`. |
+
+### Actions
+
+- Installed the current release snapshot successfully and placed `anvil` in
+  `~/.local/bin`; an interactive shell resolves `anvil 0.1.0`.
+- Opened [PR #89](https://github.com/anhermon/anvil/pull/89) for strict tool
+  input type validation.
+- Opened [PR #90](https://github.com/anhermon/anvil/pull/90) so unfinished
+  delegated runs cannot report false success.
+- Opened [PR #91](https://github.com/anhermon/anvil/pull/91) for configurable,
+  actionable, bounded Ollama waits.
+- Opened stacked [PR #92](https://github.com/anhermon/anvil/pull/92) for
+  `anvil chat`, named-session continuity, clean exit behavior, and shared
+  provider options.
+
+### Re-exercise
+
+- The installed one-shot CLI completed an Ollama run successfully.
+- Clean-main timeout tests stalled before response headers and after streaming
+  headers; both terminated within the configured test bound with actionable
+  errors.
+- Clean-main chat tests completed multiple EchoProvider prompts in one named
+  in-memory session and exited cleanly on `/exit` and EOF.
+- The combined release-snapshot build passed 92 tests (1 ignored), installed
+  to `~/.local/bin`, completed a real EchoProvider terminal chat, and exited
+  cleanly on `/exit`.
+- A real `qwen3.6:latest` run with `--ollama-timeout-secs 1` stopped within the
+  bound and reported the endpoint, likely cold model load, smaller-model
+  option, retry path, and timeout override.
+
+### Queued
+
+1. Retarget PR #92 to `main` after PR #91 lands.
+2. Decide whether installation docs should recommend `--root ~/.local` or
+   instruct users to add Cargo's bin directory to `PATH`.
+3. Re-run the 23 GB model after it is warm to separate model startup cost from
+   generation behavior.

--- a/FEEDBACK_REPORT.md
+++ b/FEEDBACK_REPORT.md
@@ -16,6 +16,54 @@ For this dogfood pass, alignment means:
 - machine-readable output identifies what actually ran; and
 - fixes are small, tested, and independently reviewable.
 
+## Standing finding: `anvil run` contaminates its own benchmarks
+
+**Every `anvil run` invocation silently injects up to 5 past episodes into the
+system prompt.** This is not opt-in and `--session` does not scope it.
+
+`Agent::build_system_prompt_with_memory` (`crates/cli/src/agent.rs`) runs a
+full-text search of the episodic memory database for the *goal text*, takes the
+top 5 matches, and prepends them to the system prompt as a
+`[Memory: N relevant episodes]` block:
+
+```rust
+match self.memory.search(goal, 5).await { /* ... prepend to system prompt ... */ }
+```
+
+The database is a single per-user SQLite file under `$HOME`
+(`~/.paperclip/harness/memory.db`). It is shared by every run, every session
+name, and every working directory. Each completed run writes its goal and
+result back into that same database.
+
+### Why this invalidates benchmark results
+
+Any harness that loops `anvil run` over a fixed set of goals is not measuring
+independent trials. Run *k* of a goal is scored with the results of runs
+*1…k-1* of that same goal pasted into its system prompt — the search key is the
+goal text, so the strongest FTS matches are always the prior attempts at the
+identical task. The measured quantity drifts from "can the model do this task"
+toward "can the model copy the answer it was handed", and it improves with
+repetition regardless of the model.
+
+The contamination is invisible in the output: the injected block is in the
+system prompt, not the transcript, and no CLI flag reports it.
+
+**Consequence: every local fine-tune comparison run through `anvil run` before
+this finding is unsound and must not be cited.** The earlier fine-tune numbers
+in particular measured accumulated memory, not model capability. They are
+withdrawn, not merely uncertain — a re-run under an isolated database is
+required before any claim about them is made again.
+
+### What a sound benchmark requires
+
+1. A per-trial empty database (point `$HOME` at a fresh temporary directory —
+   there is currently no config or flag that redirects the DB path), or
+2. a switch that disables global recall outright. This does not exist yet and
+   is the recommended fix: recall should be opt-in, not always-on.
+
+Ordering matters too: because each run writes back before the next reads, trials
+must be isolated from each other, not merely from earlier sessions.
+
 ## Iteration 1 — 2026-07-28
 
 ### Inventory
@@ -34,8 +82,9 @@ and shell tools, `spawn_subagent`, and the skill-library tools
 
 The `evolution`, `github`, and `paperclip` crates build as workspace members
 but are not wired into the shipped binary. PR #88 already covers Ollama
-small-model protocol recovery and benchmark-memory contamination, so that
-area was excluded from this pass.
+small-model protocol recovery, so that area was excluded from this pass. The
+benchmark-memory contamination described above is *not* fixed by #88 — it
+remains open; #88 only made the local run path reliable enough to observe it.
 
 ### Exercises and wins
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ ollama pull qwen2.5:3b-instruct
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Say hello in exactly three words."
 ```
 
-Ollama requests time out after 60 seconds by default. For a large model that needs longer to load,
-pass `--ollama-timeout-secs 300` or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
+Ollama requests time out after 60 seconds by default. Both `run` and `chat` accept
+`--ollama-timeout-secs 300`, or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
 
 ### Choosing a local model
 
@@ -75,6 +75,14 @@ No LLM at all? The `echo` provider mirrors input back and is what the test suite
 ```bash
 anvil run --provider echo --goal "hello"
 ```
+
+Want to keep talking without starting a new command for every prompt?
+
+```bash
+anvil chat --provider echo --session myproject
+```
+
+Chat keeps every prompt in the same named session. Type `/exit` or press Ctrl-D to leave.
 
 ---
 
@@ -105,6 +113,9 @@ Adding a provider: implement one async trait in `crates/core/src/providers/`.
 ```bash
 # Run an agent session
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Summarise the current directory"
+
+# Start an interactive chat; omit --session to generate a resumable session name
+anvil chat --provider ollama --model qwen2.5:3b-instruct --session myproject
 
 # Stream tokens as they arrive
 anvil run --provider echo --goal "hello" --stream

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ ollama pull qwen2.5:3b-instruct
 anvil run --provider ollama --model qwen2.5:3b-instruct --goal "Say hello in exactly three words."
 ```
 
+Ollama requests time out after 60 seconds by default. For a large model that needs longer to load,
+pass `--ollama-timeout-secs 300` or set `ANVIL_OLLAMA_TIMEOUT_SECS=300`.
+
 ### Choosing a local model
 
 Tool-calling ability matters far more than speed here.

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -528,8 +528,15 @@ impl Agent {
         let result = session
             .messages
             .last()
+            .filter(|message| message.role == Role::Assistant)
             .and_then(|m| m.text())
-            .unwrap_or("(sub-agent produced no output)")
+            .filter(|text| !text.trim().is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "sub-agent ended without a final assistant response \
+                     (it may have reached its iteration limit)"
+                )
+            })?
             .to_string();
 
         info!(
@@ -769,6 +776,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "context-aware result");
+    }
+
+    #[tokio::test]
+    async fn subagent_without_final_assistant_text_returns_error() {
+        let provider = Arc::new(ScriptedProvider::new(vec![tool_use_response(
+            "child-echo",
+            "echo",
+            serde_json::json!({"message": "unfinished"}),
+        )]));
+        let memory = make_memory().await;
+        let config = make_config(1);
+
+        let agent = Agent::new(provider, memory, config);
+        let result = agent.spawn_subagent("keep working", "").await;
+
+        assert!(result.is_err());
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("without a final assistant response"),
+            "unexpected error: {message}"
+        );
     }
 
     // -- New tests for memory recall and session continuity -------------------

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -554,6 +554,24 @@ impl Agent {
                         });
                     }
 
+                    // A model that re-issues the identical call will keep doing
+                    // so until the iteration cap: the tool result it just got is
+                    // the same one it already ignored, so nothing in the context
+                    // pushes it elsewhere. Say so explicitly on the channel it is
+                    // already reading.
+                    if repeated_tool_call {
+                        if let Some(ContentBlock::ToolResult { content, .. }) =
+                            result_blocks.first_mut()
+                        {
+                            content.push_str(
+                                "\n\n[harness] This is the same tool call, with the same \
+                                 arguments, as your previous turn — so this is the same result. \
+                                 Repeating it again will not help. Either use this output to \
+                                 answer, or try a materially different command.",
+                            );
+                        }
+                    }
+
                     // Feed results back as a tool-role message and continue.
                     let tool_result_msg = Message {
                         role: Role::Tool,

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -1090,4 +1090,126 @@ mod tests {
             "expected prior session history to be injected; messages: {all_text:?}"
         );
     }
+    /// The failure that motivated the recovery path: the model writes the tool
+    /// call into the message body and ends its turn. Before, the loop read that
+    /// as a final answer and stopped one step from success.
+    #[tokio::test]
+    async fn tool_call_written_as_text_is_executed() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            end_turn_response(
+                "I'll check that.\n```json\n{\"name\": \"echo\", \"input\": {\"message\": \"ping\"}}\n```",
+            ),
+            end_turn_response("done"),
+        ]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+
+        // The recovered call must have actually run: a tool-result message is
+        // present and carries the echoed payload.
+        let echoed = session.messages.iter().any(|m| {
+            m.role == Role::Tool
+                && match &m.content {
+                    MessageContent::Blocks(b) => b.iter().any(|blk| {
+                        matches!(blk, ContentBlock::ToolResult { content, .. } if content.contains("ping"))
+                    }),
+                    MessageContent::Text(t) => t.contains("ping"),
+                }
+        });
+        assert!(
+            echoed,
+            "expected the text-written tool call to execute, got: {:?}",
+            session.messages
+        );
+    }
+
+    /// A truncated fence — the model stopped mid-JSON — is still recoverable.
+    #[tokio::test]
+    async fn truncated_text_tool_call_is_recovered() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            end_turn_response("Here:\n```json\n{\"name\": \"echo\", \"input\": {\"message\": \"ping\""),
+            end_turn_response("done"),
+        ]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert!(session.messages.iter().any(|m| m.role == Role::Tool));
+    }
+
+    /// Ordinary prose must not be mistaken for a tool call — otherwise every
+    /// final answer mentioning JSON would restart the loop.
+    #[tokio::test]
+    async fn plain_final_answer_still_ends_the_run() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response(
+            "There are no TODO comments in crates/.",
+        )]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        assert!(
+            !session.messages.iter().any(|m| m.role == Role::Tool),
+            "no tool should have run for a plain prose answer"
+        );
+    }
+
+    /// An unknown tool name must not be executed just because it parsed.
+    #[tokio::test]
+    async fn text_call_to_unknown_tool_is_not_executed() {
+        let provider = Arc::new(ScriptedProvider::new(vec![end_turn_response(
+            "```json\n{\"name\": \"rm_rf\", \"input\": {\"path\": \"/\"}}\n```",
+        )]));
+
+        let agent = Agent {
+            provider,
+            memory: make_memory().await,
+            tools: {
+                let r = ToolRegistry::new();
+                r.register(EchoTool);
+                r
+            },
+            config: make_config(10),
+            depth: 0,
+            hook: Arc::new(NoopHook),
+        };
+
+        let session = agent.run("test goal").await.unwrap();
+        assert!(!session.messages.iter().any(|m| m.role == Role::Tool));
+    }
 }

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -21,6 +21,11 @@ use tracing::{debug, info, warn};
 /// Maximum sub-agent nesting depth to prevent infinite recursion.
 const MAX_SUBAGENT_DEPTH: usize = 4;
 
+/// How many times per run a tool call written as text may be recovered and
+/// executed. Bounded so a model that never uses the native channel still
+/// terminates instead of looping.
+const MAX_TEXT_CALL_RECOVERIES: usize = 3;
+
 /// Callback interface for terminal UI events emitted by the agent loop.
 ///
 /// The default no-op implementation is used for sub-agents and tests so they
@@ -60,10 +65,41 @@ pub trait UiHook: Send + Sync {
     fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
         let _ = (text, is_error, session_id);
     }
+    /// Called once per completed provider turn with structural diagnostics.
+    ///
+    /// Exists so the failure taxonomy of a run is *measured* rather than inferred
+    /// from the rendered text. Default: no-op.
+    fn on_turn_diag(&self, diag: &TurnDiag) {
+        let _ = diag;
+    }
     /// Called while waiting for the provider to return; receives `[current/max]` label.
     fn on_thinking(&self, iteration: usize, max_iter: usize);
     /// Called when the provider has returned (end of thinking).
     fn on_thinking_done(&self);
+}
+
+/// Structural facts about one completed provider turn.
+///
+/// Emitted for every turn so a run's failure mode can be classified from ground
+/// truth (what the model actually returned) instead of regexing rendered prose.
+#[derive(Debug, Clone)]
+pub struct TurnDiag {
+    /// 1-based turn index within the run.
+    pub iteration: usize,
+    /// Provider-reported stop reason, as a stable lowercase string.
+    pub stop_reason: &'static str,
+    /// Number of text blocks in the assistant message.
+    pub text_blocks: usize,
+    /// Number of native tool-use blocks in the assistant message.
+    pub tool_blocks: usize,
+    /// True when the turn carried neither text nor a tool call (the Ollama
+    /// empty-completion flake).
+    pub empty: bool,
+    /// Number of tool calls recovered from assistant *text* because the model
+    /// wrote them as prose instead of using the native tool channel.
+    pub recovered_text_calls: usize,
+    /// True when this turn's tool calls exactly repeated the previous turn's.
+    pub repeated_tool_call: bool,
 }
 
 /// Silent implementation used for sub-agents and unit tests.
@@ -257,6 +293,11 @@ impl Agent {
             .map(harness_tools::ToolSchema::to_def)
             .collect();
 
+        // Previous turn's (name, input) tool-call signature, for loop detection.
+        let mut prev_call_sig: Vec<(String, serde_json::Value)> = Vec::new();
+        // Bounded so a model that only ever writes prose cannot spin here.
+        let mut recoveries_used = 0usize;
+
         loop {
             if session.iteration >= max_iter {
                 info!("max iterations reached");
@@ -275,11 +316,50 @@ impl Agent {
             );
 
             self.hook.on_thinking(session.iteration, max_iter);
-            let response = self
+            let mut response = self
                 .provider
                 .complete_with_tools(&messages, &tool_defs)
                 .await?;
             self.hook.on_thinking_done();
+
+            // -- Recover tool calls the model wrote as text ------------------------
+            // Small local models regularly drop out of the native tool-call
+            // channel and write the call into the message body instead. Without
+            // this the loop reads that as an ordinary end-of-turn and abandons
+            // the task one step from success. Bounded per run so a model that
+            // only ever emits text cannot spin here.
+            let mut recovered_text_calls = 0usize;
+            if response.stop_reason != StopReason::ToolUse
+                && recoveries_used < MAX_TEXT_CALL_RECOVERIES
+            {
+                if let Some(text) = response.message.text() {
+                    let known: Vec<String> =
+                        self.tools.schemas().iter().map(|s| s.name.clone()).collect();
+                    let calls: Vec<_> = harness_core::toolcall_text::parse_text_tool_calls(text)
+                        .into_iter()
+                        .filter(|c| known.iter().any(|k| k == &c.name))
+                        .collect();
+                    if !calls.is_empty() {
+                        recovered_text_calls = calls.len();
+                        recoveries_used += 1;
+                        warn!(
+                            count = calls.len(),
+                            "recovered tool call(s) written as text; executing them"
+                        );
+                        let blocks = calls
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, c)| ContentBlock::ToolUse {
+                                id: format!("recovered_{}_{i}", session.iteration),
+                                name: c.name,
+                                input: c.input,
+                            })
+                            .collect();
+                        response.message.content = MessageContent::Blocks(blocks);
+                        response.stop_reason = StopReason::ToolUse;
+                    }
+                }
+            }
 
             let preview = response.message.text().unwrap_or("").to_string();
             info!(
@@ -289,6 +369,44 @@ impl Agent {
                 "response: {}",
                 &preview[..preview.len().min(120)]
             );
+
+            // -- Turn diagnostics -------------------------------------------------
+            // Emitted before any behavioural branch so the taxonomy reflects what
+            // the model actually returned, not what the loop did about it.
+            let (text_blocks, tool_blocks, call_sig) = match &response.message.content {
+                MessageContent::Blocks(blocks) => {
+                    let mut texts = 0usize;
+                    let mut sig = Vec::new();
+                    for b in blocks {
+                        match b {
+                            ContentBlock::Text { text } if !text.is_empty() => texts += 1,
+                            ContentBlock::ToolUse { name, input, .. } => {
+                                sig.push((name.clone(), input.clone()));
+                            }
+                            _ => {}
+                        }
+                    }
+                    (texts, sig.len(), sig)
+                }
+                MessageContent::Text(t) => (usize::from(!t.is_empty()), 0, Vec::new()),
+            };
+            let repeated_tool_call = !call_sig.is_empty() && call_sig == prev_call_sig;
+            prev_call_sig = call_sig;
+
+            self.hook.on_turn_diag(&TurnDiag {
+                iteration: session.iteration,
+                stop_reason: match response.stop_reason {
+                    StopReason::EndTurn => "end_turn",
+                    StopReason::ToolUse => "tool_use",
+                    StopReason::MaxTokens => "max_tokens",
+                    StopReason::StopSequence => "stop_sequence",
+                },
+                text_blocks,
+                tool_blocks,
+                empty: text_blocks == 0 && tool_blocks == 0,
+                recovered_text_calls,
+                repeated_tool_call,
+            });
 
             // Append assistant message to running history and session log.
             messages.push(response.message.clone());

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,0 +1,159 @@
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+
+use clap::Args;
+use harness_core::config::Config;
+use harness_memory::MemoryDb;
+use uuid::Uuid;
+
+use crate::agent::{Agent, RunOptions, UiHook};
+use crate::commands::{provider, run::CliHook};
+use crate::ui;
+
+#[derive(Args)]
+pub struct ChatArgs {
+    #[command(flatten)]
+    provider: provider::ProviderArgs,
+
+    /// Named session to resume. A new chat session name is generated when omitted
+    #[arg(long)]
+    pub session: Option<String>,
+
+    /// Maximum agent iterations for each prompt (default: 10). Set to 0 for unlimited
+    #[arg(long, default_value_t = 10)]
+    pub max_iterations: usize,
+}
+
+pub async fn execute(args: ChatArgs) -> anyhow::Result<()> {
+    let config = Config::load()?;
+    let resolved = provider::resolve(&config, &args.provider)?;
+    let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
+    let session_name = args
+        .session
+        .unwrap_or_else(|| format!("chat-{}", Uuid::new_v4()));
+    let hook = CliHook::new();
+    let agent = Agent::new(Arc::clone(&resolved.provider), Arc::clone(&memory), config)
+        .with_hook(Arc::clone(&hook) as Arc<dyn UiHook>);
+
+    ui::print_banner();
+    ui::print_session_header(&session_name, &resolved.model, &resolved.backend);
+    eprintln!("  Interactive chat session: {session_name}");
+    eprintln!("  Type /exit or press Ctrl-D to leave.\n");
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = stdin.lock();
+    let mut writer = stdout.lock();
+    run_chat_loop(
+        &agent,
+        &session_name,
+        args.max_iterations,
+        &mut reader,
+        &mut writer,
+    )
+    .await
+}
+
+async fn run_chat_loop<R: BufRead, W: Write>(
+    agent: &Agent,
+    session_name: &str,
+    max_iterations: usize,
+    reader: &mut R,
+    writer: &mut W,
+) -> anyhow::Result<()> {
+    let max_iterations = if max_iterations == 0 {
+        usize::MAX
+    } else {
+        max_iterations
+    };
+    let options = RunOptions {
+        session_name: Some(session_name.to_string()),
+        max_iterations: Some(max_iterations),
+    };
+
+    loop {
+        write!(writer, "you> ")?;
+        writer.flush()?;
+
+        let mut input = String::new();
+        if reader.read_line(&mut input)? == 0 {
+            writeln!(writer, "\nGoodbye.")?;
+            break;
+        }
+
+        let prompt = input.trim();
+        if prompt == "/exit" {
+            writeln!(writer, "Goodbye.")?;
+            break;
+        }
+        if prompt.is_empty() {
+            continue;
+        }
+
+        let session = agent.run_with_options(prompt, options.clone()).await?;
+        let response = session
+            .messages
+            .last()
+            .and_then(|message| message.text())
+            .unwrap_or("(no response)");
+        writeln!(writer, "anvil> {response}")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use harness_core::provider::EchoProvider;
+
+    use super::*;
+
+    async fn test_agent() -> (Agent, Arc<MemoryDb>) {
+        let memory = Arc::new(MemoryDb::in_memory().await.unwrap());
+        let agent = Agent::new(
+            Arc::new(EchoProvider),
+            Arc::clone(&memory),
+            Config::default(),
+        );
+        (agent, memory)
+    }
+
+    #[tokio::test]
+    async fn processes_multiple_prompts_in_one_named_session() {
+        let (agent, memory) = test_agent().await;
+        let mut input = Cursor::new(b"first prompt\nsecond prompt\n/exit\n");
+        let mut output = Vec::new();
+
+        run_chat_loop(&agent, "test-chat", 10, &mut input, &mut output)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("anvil> echo: first prompt"));
+        assert!(output.contains("anvil> echo: second prompt"));
+        assert!(output.ends_with("Goodbye.\n"));
+
+        let history = memory.recent_by_name("test-chat", 10).await.unwrap();
+        assert_eq!(history.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn eof_exits_cleanly_without_running_the_agent() {
+        let (agent, memory) = test_agent().await;
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let mut output = Vec::new();
+
+        run_chat_loop(&agent, "empty-chat", 10, &mut input, &mut output)
+            .await
+            .unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap(), "you> \nGoodbye.\n");
+        assert!(memory
+            .recent_by_name("empty-chat", 10)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod auth;
+pub mod chat;
 pub mod config;
 pub mod eval;
 pub mod memory;
+pub(crate) mod provider;
 pub mod run;

--- a/crates/cli/src/commands/provider.rs
+++ b/crates/cli/src/commands/provider.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Args;
+use harness_core::{
+    config::Config,
+    provider::Provider,
+    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
+    providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
+};
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct ProviderArgs {
+    /// Provider backend override (claude, claude-code, cc, ollama, echo)
+    #[arg(long, env = "HARNESS_PROVIDER")]
+    pub(crate) provider: Option<String>,
+
+    /// Model identifier override (e.g. "gemma4:e2b")
+    #[arg(long, env = "HARNESS_MODEL")]
+    pub(crate) model: Option<String>,
+
+    /// Maximum seconds to wait for each Ollama request
+    #[arg(
+        long,
+        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
+        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
+        value_parser = parse_positive_timeout
+    )]
+    pub(crate) ollama_timeout_secs: u64,
+}
+
+pub(crate) struct ResolvedProvider {
+    pub(crate) backend: String,
+    pub(crate) model: String,
+    pub(crate) provider: Arc<dyn Provider>,
+}
+
+pub(crate) fn resolve(config: &Config, args: &ProviderArgs) -> anyhow::Result<ResolvedProvider> {
+    let provider_override = args.provider.as_deref();
+    let mut backend = provider_override
+        .unwrap_or(&config.provider.backend)
+        .to_string();
+    let model = args
+        .model
+        .as_deref()
+        .unwrap_or(&config.provider.model)
+        .to_string();
+
+    // Auto-detect ollama when no provider is explicitly specified and the model
+    // doesn't look like a known Claude or OpenAI model.
+    if provider_override.is_none()
+        && !model.starts_with("claude")
+        && !model.starts_with("anthropic/")
+        && !model.starts_with("gpt-")
+        && !model.starts_with("openai/")
+    {
+        tracing::info!(model = %model, "auto-detecting ollama provider from model name");
+        backend = "ollama".to_string();
+    }
+
+    let provider: Arc<dyn Provider> = match backend.as_str() {
+        "echo" => {
+            tracing::info!("using echo provider (no LLM calls)");
+            Arc::new(harness_core::provider::EchoProvider)
+        }
+        "claude-code" | "cc" => {
+            tracing::info!(model = %model, "using ClaudeCodeProvider (subprocess)");
+            Arc::new(ClaudeCodeProvider::new(&model))
+        }
+        "ollama" => build_ollama_provider(config, &model, args.ollama_timeout_secs),
+        _ => Arc::new(
+            ClaudeProvider::from_env(&model, config.provider.max_tokens)
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+        ),
+    };
+
+    Ok(ResolvedProvider {
+        backend,
+        model,
+        provider,
+    })
+}
+
+fn build_ollama_provider(config: &Config, model: &str, timeout_secs: u64) -> Arc<dyn Provider> {
+    let base_url = config
+        .provider
+        .base_url
+        .as_deref()
+        .unwrap_or("http://localhost:11434");
+    tracing::info!(model, base_url, timeout_secs, "using OllamaProvider");
+    Arc::new(OllamaProvider::with_timeout(
+        base_url,
+        model,
+        config.provider.max_tokens,
+        Duration::from_secs(timeout_secs),
+    ))
+}
+
+fn parse_positive_timeout(value: &str) -> Result<u64, String> {
+    match value.parse::<u64>() {
+        Ok(seconds) if seconds > 0 => Ok(seconds),
+        _ => Err("timeout must be a positive number of seconds".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_args(provider: Option<&str>, model: Option<&str>) -> ProviderArgs {
+        ProviderArgs {
+            provider: provider.map(str::to_string),
+            model: model.map(str::to_string),
+            ollama_timeout_secs: DEFAULT_OLLAMA_TIMEOUT_SECS,
+        }
+    }
+
+    #[test]
+    fn echo_provider_can_be_selected_without_credentials() {
+        let config = Config::default();
+        let resolved = resolve(&config, &provider_args(Some("echo"), Some("test-model"))).unwrap();
+
+        assert_eq!(resolved.backend, "echo");
+        assert_eq!(resolved.model, "test-model");
+        assert_eq!(resolved.provider.name(), "echo");
+    }
+
+    #[test]
+    fn local_model_auto_selects_ollama_without_provider_override() {
+        let config = Config::default();
+        let resolved = resolve(&config, &provider_args(None, Some("qwen2.5:3b"))).unwrap();
+
+        assert_eq!(resolved.backend, "ollama");
+        assert_eq!(resolved.model, "qwen2.5:3b");
+    }
+
+    #[test]
+    fn ollama_timeout_must_be_positive() {
+        assert_eq!(parse_positive_timeout("45"), Ok(45));
+        assert!(parse_positive_timeout("0").is_err());
+        assert!(parse_positive_timeout("not-a-number").is_err());
+    }
+}

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use clap::Args;
 use harness_core::{
     config::Config,
     provider::Provider,
+    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
     providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
 };
 use harness_memory::MemoryDb;
@@ -12,6 +13,13 @@ use indicatif::ProgressBar;
 
 use crate::agent::{Agent, RunOptions, UiHook};
 use crate::ui;
+
+fn parse_positive_timeout(value: &str) -> Result<u64, String> {
+    match value.parse::<u64>() {
+        Ok(seconds) if seconds > 0 => Ok(seconds),
+        _ => Err("timeout must be a positive number of seconds".to_string()),
+    }
+}
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -26,6 +34,15 @@ pub struct RunArgs {
     /// Model identifier override (e.g. "gemma4:e2b")
     #[arg(long, env = "HARNESS_MODEL")]
     pub model: Option<String>,
+
+    /// Maximum seconds to wait for each Ollama request
+    #[arg(
+        long,
+        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
+        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
+        value_parser = parse_positive_timeout
+    )]
+    pub ollama_timeout_secs: u64,
 
     /// Stream response tokens to stdout as they arrive
     #[arg(long)]
@@ -271,11 +288,17 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
                 .base_url
                 .as_deref()
                 .unwrap_or("http://localhost:11434");
-            tracing::info!(model = %model, base_url = %base_url, "using OllamaProvider");
-            Arc::new(OllamaProvider::new(
+            tracing::info!(
+                model = %model,
+                base_url = %base_url,
+                timeout_secs = args.ollama_timeout_secs,
+                "using OllamaProvider"
+            );
+            Arc::new(OllamaProvider::with_timeout(
                 base_url,
                 &model,
                 config.provider.max_tokens,
+                Duration::from_secs(args.ollama_timeout_secs),
             ))
         }
         _ => Arc::new(
@@ -368,4 +391,16 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_positive_timeout;
+
+    #[test]
+    fn ollama_timeout_must_be_positive() {
+        assert_eq!(parse_positive_timeout("45"), Ok(45));
+        assert!(parse_positive_timeout("0").is_err());
+        assert!(parse_positive_timeout("not-a-number").is_err());
+    }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -52,6 +52,11 @@ pub struct RunArgs {
     /// Use this flag when calling `anvil run` from a machine-readable context (e.g. Paperclip adapter).
     #[arg(long)]
     pub json_output: bool,
+
+    /// Sampling temperature for local (Ollama) models. Lower is more literal;
+    /// the default suits tool-calling. Ignored by hosted providers.
+    #[arg(long)]
+    pub temperature: Option<f32>,
 }
 
 // ── Terminal (coloured) hook ──────────────────────────────────────────────────
@@ -212,6 +217,21 @@ impl UiHook for JsonHook {
         }));
     }
 
+    fn on_turn_diag(&self, diag: &crate::agent::TurnDiag) {
+        Self::emit(&serde_json::json!({
+            "type": "turn",
+            "part": {
+                "iteration": diag.iteration,
+                "stopReason": diag.stop_reason,
+                "textBlocks": diag.text_blocks,
+                "toolBlocks": diag.tool_blocks,
+                "empty": diag.empty,
+                "recoveredTextCalls": diag.recovered_text_calls,
+                "repeatedToolCall": diag.repeated_tool_call,
+            }
+        }));
+    }
+
     fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
         Self::emit(&serde_json::json!({
             "type": "result",
@@ -272,11 +292,11 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
                 .as_deref()
                 .unwrap_or("http://localhost:11434");
             tracing::info!(model = %model, base_url = %base_url, "using OllamaProvider");
-            Arc::new(OllamaProvider::new(
-                base_url,
-                &model,
-                config.provider.max_tokens,
-            ))
+            let mut p = OllamaProvider::new(base_url, &model, config.provider.max_tokens);
+            if let Some(t) = args.temperature {
+                p = p.with_temperature(t);
+            }
+            Arc::new(p)
         }
         _ => Arc::new(
             ClaudeProvider::from_env(&model, config.provider.max_tokens)

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,25 +1,14 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use clap::Args;
-use harness_core::{
-    config::Config,
-    provider::Provider,
-    providers::ollama::DEFAULT_OLLAMA_TIMEOUT_SECS,
-    providers::{ClaudeCodeProvider, ClaudeProvider, OllamaProvider},
-};
+use harness_core::config::Config;
 use harness_memory::MemoryDb;
 use indicatif::ProgressBar;
 
 use crate::agent::{Agent, RunOptions, UiHook};
+use crate::commands::provider;
 use crate::ui;
-
-fn parse_positive_timeout(value: &str) -> Result<u64, String> {
-    match value.parse::<u64>() {
-        Ok(seconds) if seconds > 0 => Ok(seconds),
-        _ => Err("timeout must be a positive number of seconds".to_string()),
-    }
-}
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -27,22 +16,8 @@ pub struct RunArgs {
     #[arg(short, long)]
     pub goal: String,
 
-    /// Provider backend override (claude, claude-code, cc, ollama, echo)
-    #[arg(long, env = "HARNESS_PROVIDER")]
-    pub provider: Option<String>,
-
-    /// Model identifier override (e.g. "gemma4:e2b")
-    #[arg(long, env = "HARNESS_MODEL")]
-    pub model: Option<String>,
-
-    /// Maximum seconds to wait for each Ollama request
-    #[arg(
-        long,
-        env = "ANVIL_OLLAMA_TIMEOUT_SECS",
-        default_value_t = DEFAULT_OLLAMA_TIMEOUT_SECS,
-        value_parser = parse_positive_timeout
-    )]
-    pub ollama_timeout_secs: u64,
+    #[command(flatten)]
+    provider: provider::ProviderArgs,
 
     /// Stream response tokens to stdout as they arrive
     #[arg(long)]
@@ -74,12 +49,12 @@ pub struct RunArgs {
 // ── Terminal (coloured) hook ──────────────────────────────────────────────────
 
 /// CLI UI hook: drives the spinner and prints tool call/result lines.
-struct CliHook {
+pub(crate) struct CliHook {
     spinner: std::sync::Mutex<Option<ProgressBar>>,
 }
 
 impl CliHook {
-    fn new() -> Arc<Self> {
+    pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
             spinner: std::sync::Mutex::new(None),
         })
@@ -248,64 +223,10 @@ impl UiHook for JsonHook {
 #[allow(clippy::too_many_lines)]
 pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     let config = Config::load()?;
-
-    let backend_override = args.provider.as_deref();
-    let mut backend = args
-        .provider
-        .as_deref()
-        .unwrap_or(&config.provider.backend)
-        .to_string();
-    let model = args
-        .model
-        .as_deref()
-        .unwrap_or(&config.provider.model)
-        .to_string();
-
-    // Auto-detect ollama when no provider is explicitly specified and the model
-    // doesn't look like a known Claude or OpenAI model.
-    if backend_override.is_none()
-        && !model.starts_with("claude")
-        && !model.starts_with("anthropic/")
-        && !model.starts_with("gpt-")
-        && !model.starts_with("openai/")
-    {
-        tracing::info!(model = %model, "auto-detecting ollama provider from model name");
-        backend = "ollama".to_string();
-    }
-
-    let provider: Arc<dyn Provider> = match backend.as_str() {
-        "echo" => {
-            tracing::info!("using echo provider (no LLM calls)");
-            Arc::new(harness_core::provider::EchoProvider)
-        }
-        "claude-code" | "cc" => {
-            tracing::info!(model = %model, "using ClaudeCodeProvider (subprocess)");
-            Arc::new(ClaudeCodeProvider::new(&model))
-        }
-        "ollama" => {
-            let base_url = config
-                .provider
-                .base_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434");
-            tracing::info!(
-                model = %model,
-                base_url = %base_url,
-                timeout_secs = args.ollama_timeout_secs,
-                "using OllamaProvider"
-            );
-            Arc::new(OllamaProvider::with_timeout(
-                base_url,
-                &model,
-                config.provider.max_tokens,
-                Duration::from_secs(args.ollama_timeout_secs),
-            ))
-        }
-        _ => Arc::new(
-            ClaudeProvider::from_env(&model, config.provider.max_tokens)
-                .map_err(|e| anyhow::anyhow!("{e}"))?,
-        ),
-    };
+    let resolved = provider::resolve(&config, &args.provider)?;
+    let backend = resolved.backend;
+    let model = resolved.model;
+    let provider = resolved.provider;
 
     let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
 
@@ -391,16 +312,4 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_positive_timeout;
-
-    #[test]
-    fn ollama_timeout_must_be_positive() {
-        assert_eq!(parse_positive_timeout("45"), Ok(45));
-        assert!(parse_positive_timeout("0").is_err());
-        assert!(parse_positive_timeout("not-a-number").is_err());
-    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,8 @@ struct Cli {
 enum Commands {
     /// Run an agent turn toward a goal
     Run(commands::run::RunArgs),
+    /// Start an interactive multi-turn chat session
+    Chat(commands::chat::ChatArgs),
     /// Show current configuration
     Config(commands::config::ConfigArgs),
     /// Manage and inspect memory
@@ -55,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Run(args) => commands::run::execute(args).await,
+        Commands::Chat(args) => commands::chat::execute(args).await,
         Commands::Config(args) => commands::config::execute(args).await,
         Commands::Memory(args) => commands::memory::execute(args).await,
         Commands::Eval(args) => commands::eval::execute(args).await,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,3 +7,4 @@ pub mod message;
 pub mod provider;
 pub mod providers;
 pub mod session;
+pub mod toolcall_text;

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -108,3 +108,68 @@ pub struct TurnResponse {
     pub usage: Usage,
     pub model: String,
 }
+
+impl TurnResponse {
+    /// True when the turn carried no usable content at all — no text and no
+    /// tool call.
+    ///
+    /// Distinguishes a provider-level flake (worth retrying) from a model that
+    /// deliberately ended its turn with an answer.
+    #[must_use]
+    pub fn is_empty_turn(&self) -> bool {
+        match &self.message.content {
+            MessageContent::Text(t) => t.trim().is_empty(),
+            MessageContent::Blocks(blocks) => !blocks.iter().any(|b| match b {
+                ContentBlock::Text { text } => !text.trim().is_empty(),
+                ContentBlock::ToolUse { .. } => true,
+                ContentBlock::ToolResult { .. } => false,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod turn_response_tests {
+    use super::{ContentBlock, Message, MessageContent, Role, StopReason, TurnResponse, Usage};
+
+    fn resp(content: MessageContent) -> TurnResponse {
+        TurnResponse {
+            message: Message {
+                role: Role::Assistant,
+                content,
+            },
+            stop_reason: StopReason::EndTurn,
+            usage: Usage::default(),
+            model: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_blocks_is_empty() {
+        assert!(resp(MessageContent::Blocks(vec![])).is_empty_turn());
+    }
+
+    #[test]
+    fn whitespace_only_text_is_empty() {
+        assert!(resp(MessageContent::Text("   \n".into())).is_empty_turn());
+        assert!(resp(MessageContent::Blocks(vec![ContentBlock::Text {
+            text: "  ".into()
+        }]))
+        .is_empty_turn());
+    }
+
+    #[test]
+    fn real_text_is_not_empty() {
+        assert!(!resp(MessageContent::Text("hello".into())).is_empty_turn());
+    }
+
+    #[test]
+    fn tool_call_alone_is_not_empty() {
+        assert!(!resp(MessageContent::Blocks(vec![ContentBlock::ToolUse {
+            id: "1".into(),
+            name: "bash".into(),
+            input: serde_json::json!({}),
+        }]))
+        .is_empty_turn());
+    }
+}

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -10,24 +10,48 @@ use crate::{
     provider::{Provider, StreamChunk, TokenStream, ToolDef},
 };
 
+/// Sampling temperature used when the caller does not specify one.
+///
+/// Ollama's own default is 0.8, which is tuned for open-ended chat. Local
+/// instruct models at that temperature drift out of the tool-call format —
+/// malformed JSON arguments and broken shell quoting. Agentic tool selection
+/// wants near-greedy decoding instead.
+pub const DEFAULT_TEMPERATURE: f32 = 0.2;
+
+/// How many times to re-request a turn that came back completely empty.
+///
+/// Ollama returns a well-formed HTTP 200 with neither content nor tool calls at
+/// a measurable rate on small local models. Without a retry the agent loop reads
+/// it as an ordinary end-of-turn and abandons the task.
+const EMPTY_RESPONSE_RETRIES: usize = 2;
+
 pub struct OllamaProvider {
     client: Client,
     model: String,
     base_url: String,
     max_tokens: u32,
+    temperature: f32,
 }
 
 impl OllamaProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>, max_tokens: u32) -> Self {
         Self {
             client: Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
+                .timeout(std::time::Duration::from_secs(120))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
+            temperature: DEFAULT_TEMPERATURE,
         }
+    }
+
+    /// Override the sampling temperature.
+    #[must_use]
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
     }
 
     fn endpoint(&self) -> String {
@@ -134,6 +158,7 @@ struct OpenAiRequest<'a> {
     messages: Vec<OpenAiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    temperature: f32,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiTool>>,
@@ -238,6 +263,45 @@ impl Provider for OllamaProvider {
         messages: &[Message],
         tools: &[ToolDef],
     ) -> Result<TurnResponse> {
+        // Retry completely empty completions. Ollama returns these at a
+        // measurable rate for small local models; they are a transport-level
+        // flake, not a decision by the model to stop, so re-asking is correct.
+        let mut last = self.complete_once(messages, tools).await?;
+        for attempt in 1..=EMPTY_RESPONSE_RETRIES {
+            if !last.is_empty_turn() {
+                break;
+            }
+            warn!(
+                attempt,
+                model = %self.model,
+                "Ollama returned an empty completion; retrying"
+            );
+            last = self.complete_once(messages, tools).await?;
+        }
+        Ok(last)
+    }
+
+    async fn stream(&self, messages: &[Message]) -> Result<TokenStream> {
+        self.stream_with_tools(messages, &[]).await
+    }
+
+    // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
+    #[allow(clippy::too_many_lines)]
+    async fn stream_with_tools(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<TokenStream> {
+        self.stream_with_tools_inner(messages, tools).await
+    }
+}
+
+impl OllamaProvider {
+    async fn complete_once(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+    ) -> Result<TurnResponse> {
         let openai_tools = if tools.is_empty() {
             None
         } else {
@@ -260,6 +324,7 @@ impl Provider for OllamaProvider {
             model: &self.model,
             messages: Self::build_openai_messages(messages),
             max_tokens: Some(self.max_tokens),
+            temperature: self.temperature,
             stream: false,
             tools: openai_tools,
             tool_choice: if tools.is_empty() {
@@ -313,17 +378,29 @@ impl Provider for OllamaProvider {
 
         if let Some(tool_calls) = &choice.message.tool_calls {
             for tc in tool_calls {
-                match serde_json::from_str::<serde_json::Value>(&tc.function.arguments) {
-                    Ok(input) => {
-                        blocks.push(ContentBlock::ToolUse {
-                            id: tc.id.clone(),
-                            name: tc.function.name.clone(),
-                            input,
-                        });
-                    }
+                // A native call whose arguments are near-miss JSON (a raw newline
+                // inside a shell command, a trailing comma, a truncated tail) used
+                // to be dropped on the floor, which read to the agent loop as "the
+                // model chose not to call a tool". Repair it instead.
+                let input = match serde_json::from_str::<serde_json::Value>(&tc.function.arguments)
+                {
+                    Ok(v) => Some(v),
                     Err(e) => {
-                        warn!(error = %e, "failed to parse tool arguments from Ollama");
+                        let repaired = crate::toolcall_text::repair_json(&tc.function.arguments);
+                        if repaired.is_some() {
+                            warn!(error = %e, tool = %tc.function.name, "repaired malformed tool arguments from Ollama");
+                        } else {
+                            warn!(error = %e, tool = %tc.function.name, "failed to parse tool arguments from Ollama");
+                        }
+                        repaired
                     }
+                };
+                if let Some(input) = input {
+                    blocks.push(ContentBlock::ToolUse {
+                        id: tc.id.clone(),
+                        name: tc.function.name.clone(),
+                        input,
+                    });
                 }
             }
         }
@@ -348,13 +425,9 @@ impl Provider for OllamaProvider {
         })
     }
 
-    async fn stream(&self, messages: &[Message]) -> Result<TokenStream> {
-        self.stream_with_tools(messages, &[]).await
-    }
-
     // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
     #[allow(clippy::too_many_lines)]
-    async fn stream_with_tools(
+    async fn stream_with_tools_inner(
         &self,
         messages: &[Message],
         tools: &[ToolDef],
@@ -381,6 +454,7 @@ impl Provider for OllamaProvider {
             model: &self.model,
             messages: Self::build_openai_messages(messages),
             max_tokens: Some(self.max_tokens),
+            temperature: self.temperature,
             stream: true,
             tools: openai_tools,
             tool_choice: if tools.is_empty() {

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -297,6 +297,8 @@ impl Provider for OllamaProvider {
 }
 
 impl OllamaProvider {
+    // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
+    #[allow(clippy::too_many_lines)]
     async fn complete_once(
         &self,
         messages: &[Message],

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client;
@@ -15,18 +17,54 @@ pub struct OllamaProvider {
     model: String,
     base_url: String,
     max_tokens: u32,
+    request_timeout: Duration,
+}
+
+pub const DEFAULT_OLLAMA_TIMEOUT_SECS: u64 = 60;
+
+fn timeout_label(timeout: Duration) -> String {
+    if timeout.as_secs() > 0 {
+        format!("{}s", timeout.as_secs())
+    } else {
+        format!("{}ms", timeout.as_millis())
+    }
+}
+
+fn ollama_request_error(error: &reqwest::Error, timeout: Duration, endpoint: &str) -> HarnessError {
+    if error.is_timeout() {
+        HarnessError::Provider(format!(
+            "Ollama request to {endpoint} timed out after {}. \
+             The model may still be loading; retry, choose a smaller model, or increase \
+             --ollama-timeout-secs (ANVIL_OLLAMA_TIMEOUT_SECS).",
+            timeout_label(timeout)
+        ))
+    } else {
+        HarnessError::Provider(error.to_string())
+    }
 }
 
 impl OllamaProvider {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>, max_tokens: u32) -> Self {
+        Self::with_timeout(
+            base_url,
+            model,
+            max_tokens,
+            Duration::from_secs(DEFAULT_OLLAMA_TIMEOUT_SECS),
+        )
+    }
+
+    pub fn with_timeout(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+        request_timeout: Duration,
+    ) -> Self {
         Self {
-            client: Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
-                .build()
-                .unwrap_or_else(|_| Client::new()),
+            client: Client::new(),
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
+            request_timeout,
         }
     }
 
@@ -35,6 +73,10 @@ impl OllamaProvider {
             "{}/v1/chat/completions",
             self.base_url.trim_end_matches('/')
         )
+    }
+
+    fn request(&self, endpoint: &str) -> reqwest::RequestBuilder {
+        self.client.post(endpoint).timeout(self.request_timeout)
     }
 
     fn build_openai_messages(messages: &[Message]) -> Vec<OpenAiMessage> {
@@ -269,29 +311,32 @@ impl Provider for OllamaProvider {
             },
         };
 
-        debug!(model = %self.model, url = %self.endpoint(), "sending request to Ollama (OpenAI-compatible)");
+        let endpoint = self.endpoint();
+        debug!(model = %self.model, url = %endpoint, "sending request to Ollama (OpenAI-compatible)");
 
         let resp = self
-            .client
-            .post(self.endpoint())
+            .request(&endpoint)
             .json(&body)
             .send()
             .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+            .map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
 
         let status = resp.status();
         if !status.is_success() {
-            let raw = resp.text().await.unwrap_or_default();
+            let raw = resp.text().await.map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
             return Err(HarnessError::Api {
                 status: status.as_u16(),
                 body: raw,
             });
         }
 
-        let api_resp: OpenAiResponse = resp
-            .json()
-            .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+        let api_resp: OpenAiResponse = resp.json().await.map_err(|error| {
+            ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+        })?;
 
         let choice = api_resp
             .choices
@@ -390,17 +435,21 @@ impl Provider for OllamaProvider {
             },
         };
 
+        let endpoint = self.endpoint();
         let resp = self
-            .client
-            .post(self.endpoint())
+            .request(&endpoint)
             .json(&body)
             .send()
             .await
-            .map_err(|e| HarnessError::Provider(e.to_string()))?;
+            .map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
 
         let status = resp.status();
         if !status.is_success() {
-            let raw = resp.text().await.unwrap_or_default();
+            let raw = resp.text().await.map_err(|error| {
+                ollama_request_error(&error, self.request_timeout, endpoint.as_str())
+            })?;
             return Err(HarnessError::Api {
                 status: status.as_u16(),
                 body: raw,
@@ -409,6 +458,7 @@ impl Provider for OllamaProvider {
 
         let (tx, rx) = futures::channel::mpsc::channel::<Result<StreamChunk>>(64);
         let mut byte_stream = resp.bytes_stream();
+        let request_timeout = self.request_timeout;
 
         tokio::spawn(async move {
             let mut tx = tx;
@@ -417,7 +467,11 @@ impl Provider for OllamaProvider {
             while let Some(item) = byte_stream.next().await {
                 match item {
                     Err(e) => {
-                        let _ = tx.try_send(Err(HarnessError::Provider(e.to_string())));
+                        let _ = tx.try_send(Err(ollama_request_error(
+                            &e,
+                            request_timeout,
+                            endpoint.as_str(),
+                        )));
                         return;
                     }
                     Ok(bytes) => {
@@ -476,5 +530,77 @@ impl Provider for OllamaProvider {
         });
 
         Ok(Box::pin(rx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    async fn spawn_stalled_server(send_headers: bool) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = socket.read(&mut request).await;
+            if send_headers {
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\n\
+                          Content-Type: text/event-stream\r\n\
+                          Transfer-Encoding: chunked\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            }
+            std::future::pending::<()>().await;
+        });
+        (format!("http://{address}"), task)
+    }
+
+    #[tokio::test]
+    async fn non_streaming_request_timeout_is_bounded_and_actionable() {
+        let (base_url, server) = spawn_stalled_server(false).await;
+        let provider =
+            OllamaProvider::with_timeout(base_url, "test-model", 128, Duration::from_millis(100));
+
+        let error = provider
+            .complete(&[Message::user("hello")])
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+
+        assert!(error.contains("timed out after 100ms"), "{error}");
+        assert!(error.contains("--ollama-timeout-secs"), "{error}");
+        assert!(error.contains("model may still be loading"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn streaming_body_timeout_is_bounded_and_actionable() {
+        let (base_url, server) = spawn_stalled_server(true).await;
+        let provider =
+            OllamaProvider::with_timeout(base_url, "test-model", 128, Duration::from_millis(100));
+
+        let mut stream = provider
+            .stream(&[Message::user("hello")])
+            .await
+            .expect("response headers should arrive before the timeout");
+        let error = stream
+            .next()
+            .await
+            .expect("stream should report the timeout")
+            .unwrap_err()
+            .to_string();
+        server.abort();
+
+        assert!(error.contains("timed out after 100ms"), "{error}");
+        assert!(error.contains("--ollama-timeout-secs"), "{error}");
     }
 }

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -10,14 +10,6 @@ use crate::{
     provider::{Provider, StreamChunk, TokenStream, ToolDef},
 };
 
-/// Sampling temperature used when the caller does not specify one.
-///
-/// Ollama's own default is 0.8, which is tuned for open-ended chat. Local
-/// instruct models at that temperature drift out of the tool-call format —
-/// malformed JSON arguments and broken shell quoting. Agentic tool selection
-/// wants near-greedy decoding instead.
-pub const DEFAULT_TEMPERATURE: f32 = 0.2;
-
 /// How many times to re-request a turn that came back completely empty.
 ///
 /// Ollama returns a well-formed HTTP 200 with neither content nor tool calls at
@@ -30,7 +22,14 @@ pub struct OllamaProvider {
     model: String,
     base_url: String,
     max_tokens: u32,
-    temperature: f32,
+    /// `None` leaves sampling to the server's own default.
+    ///
+    /// Near-greedy decoding looks right for tool calling on priors, but
+    /// measured the opposite on `qwen2.5:3b-instruct`: at 0.2 the model locks
+    /// onto a wrong conclusion ("none of the provided functions can be used")
+    /// and re-emits identical tool calls instead of varying its retry. Left
+    /// unset unless the caller asks.
+    temperature: Option<f32>,
 }
 
 impl OllamaProvider {
@@ -43,14 +42,14 @@ impl OllamaProvider {
             base_url: base_url.into(),
             model: model.into(),
             max_tokens,
-            temperature: DEFAULT_TEMPERATURE,
+            temperature: None,
         }
     }
 
-    /// Override the sampling temperature.
+    /// Pin the sampling temperature instead of using the server default.
     #[must_use]
     pub fn with_temperature(mut self, temperature: f32) -> Self {
-        self.temperature = temperature;
+        self.temperature = Some(temperature);
         self
     }
 
@@ -158,7 +157,8 @@ struct OpenAiRequest<'a> {
     messages: Vec<OpenAiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
-    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiTool>>,

--- a/crates/core/src/toolcall_text.rs
+++ b/crates/core/src/toolcall_text.rs
@@ -1,0 +1,398 @@
+//! Recovery of tool calls that a model wrote as *text* instead of emitting on
+//! the native tool-call channel.
+//!
+//! Small local models (qwen2.5:3b class, served through Ollama) regularly slip
+//! out of the OpenAI `tool_calls` channel and write the call into the assistant
+//! message body instead — as a ```` ```json ```` fence, a `<tool_call>` tag, or a
+//! bare JSON object. A harness that only reads native `tool_calls` sees an
+//! ordinary end-of-turn and stops the run, so a recoverable formatting slip
+//! becomes a silent task failure.
+//!
+//! This module is pure and provider-agnostic: it turns text into candidate
+//! calls. Deciding whether to *execute* a recovered call is the agent loop's
+//! job.
+
+use serde_json::{Map, Value};
+
+/// A tool call recovered from assistant text.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedCall {
+    /// Tool name as written by the model.
+    pub name: String,
+    /// Arguments object (possibly repaired).
+    pub input: Value,
+    /// Which text encoding it was recovered from — useful for diagnostics.
+    pub format: CallFormat,
+}
+
+/// The text encoding a recovered call was written in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallFormat {
+    /// ```` ```tool ```` or ```` ```json ```` fenced block.
+    Fenced,
+    /// `<tool_call>…</tool_call>` tag.
+    Tag,
+    /// A bare JSON object sitting in the prose.
+    Bare,
+}
+
+/// Re-escape raw control characters that appear *inside* JSON string literals.
+///
+/// Models routinely emit a literal newline inside a string (common when the
+/// argument is a shell command or file body), which is invalid JSON.
+fn escape_control_chars_in_strings(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut in_string = false;
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if in_string && ch == '\\' {
+            out.push(ch);
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+            continue;
+        }
+        match ch {
+            '"' => {
+                in_string = !in_string;
+                out.push(ch);
+            }
+            '\n' if in_string => out.push_str("\\n"),
+            '\t' if in_string => out.push_str("\\t"),
+            '\r' if in_string => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Balance unclosed `{`/`[` by appending the missing closers.
+///
+/// Only counts brackets outside string literals, so a `}` inside a shell
+/// command doesn't throw the count off.
+fn close_unbalanced(text: &str) -> String {
+    let mut braces = 0i32;
+    let mut squares = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in text.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => braces += 1,
+            '}' => braces -= 1,
+            '[' => squares += 1,
+            ']' => squares -= 1,
+            _ => {}
+        }
+    }
+    let mut out = text.to_string();
+    // An unterminated string must be closed before its containing brackets.
+    if in_string {
+        out.push('"');
+    }
+    for _ in 0..squares.max(0) {
+        out.push(']');
+    }
+    for _ in 0..braces.max(0) {
+        out.push('}');
+    }
+    out
+}
+
+/// Best-effort JSON repair for near-miss model output.
+///
+/// Tries progressively more aggressive fixes and returns the first that parses.
+/// Returns `None` when the text cannot be salvaged into an object.
+#[must_use]
+pub fn repair_json(raw: &str) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // 1. As-is.
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(trimmed) {
+        return Some(v);
+    }
+    // 2. Re-escape raw control characters inside strings.
+    let mut fixed = escape_control_chars_in_strings(trimmed);
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&fixed) {
+        return Some(v);
+    }
+    // 3. Drop trailing commas before a closer.
+    fixed = fixed.replace(",}", "}").replace(",]", "]");
+    fixed = fixed.replace(", }", "}").replace(", ]", "]");
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&fixed) {
+        return Some(v);
+    }
+    // 4. Close unbalanced brackets — the truncation case (model hit max_tokens
+    //    or stopped mid-fence).
+    let closed = close_unbalanced(&fixed);
+    if let Ok(v @ Value::Object(_)) = serde_json::from_str::<Value>(&closed) {
+        return Some(v);
+    }
+    None
+}
+
+/// Pull the arguments object out of a decoded call, accepting the several key
+/// names models use interchangeably.
+fn extract_input(obj: &Map<String, Value>) -> Value {
+    for key in ["input", "arguments", "parameters", "args"] {
+        if let Some(v) = obj.get(key) {
+            // Some models double-encode the arguments as a JSON *string*.
+            if let Value::String(s) = v {
+                if let Some(parsed) = repair_json(s) {
+                    return parsed;
+                }
+            }
+            if v.is_object() {
+                return v.clone();
+            }
+        }
+    }
+    Value::Object(Map::new())
+}
+
+/// Build a call from a decoded JSON object, if it names a tool.
+fn call_from_value(v: &Value, format: CallFormat) -> Option<ParsedCall> {
+    let obj = v.as_object()?;
+    // Accept both the flat `{"name":…}` shape and OpenAI's `{"function":{…}}`.
+    let inner = obj
+        .get("function")
+        .and_then(Value::as_object)
+        .unwrap_or(obj);
+    let name = inner.get("name")?.as_str()?.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    Some(ParsedCall {
+        name,
+        input: extract_input(inner),
+        format,
+    })
+}
+
+/// Find each region between `open` and `close`, returning the inner slices.
+fn between<'a>(text: &'a str, open: &str, close: &str) -> Vec<&'a str> {
+    let mut found = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find(open) {
+        let after = &rest[start + open.len()..];
+        // An unterminated final block still carries a usable (truncated) payload.
+        let (body, next) = match after.find(close) {
+            Some(end) => (&after[..end], &after[end + close.len()..]),
+            None => (after, ""),
+        };
+        found.push(body);
+        if next.is_empty() {
+            break;
+        }
+        rest = next;
+    }
+    found
+}
+
+/// Extract the outermost balanced `{…}` regions of `text`, ignoring braces
+/// inside string literals.
+fn top_level_objects(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => {
+                if depth == 0 {
+                    start = i;
+                }
+                depth += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 && i >= start {
+                    if let Some(s) = text.get(start..=i) {
+                        out.push(s);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    // A truncated trailing object is still worth a repair attempt.
+    if depth > 0 {
+        if let Some(s) = text.get(start..) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Recover tool calls a model wrote into assistant text.
+///
+/// Checks, in order: ```` ``` ````-fenced blocks, `<tool_call>` tags, then bare
+/// JSON objects. Bare objects are only considered when neither of the explicit
+/// forms matched, since prose containing an unrelated JSON example would
+/// otherwise be misread as a call.
+#[must_use]
+pub fn parse_text_tool_calls(text: &str) -> Vec<ParsedCall> {
+    let mut calls = Vec::new();
+
+    // Fenced: ```tool / ```json / ```tool_call
+    for marker in ["```tool_call", "```tool", "```json"] {
+        for body in between(text, marker, "```") {
+            if let Some(v) = repair_json(body) {
+                if let Some(c) = call_from_value(&v, CallFormat::Fenced) {
+                    calls.push(c);
+                }
+            }
+        }
+        if !calls.is_empty() {
+            break;
+        }
+    }
+
+    // Tagged: <tool_call>…</tool_call>
+    for body in between(text, "<tool_call>", "</tool_call>") {
+        if let Some(v) = repair_json(body) {
+            if let Some(c) = call_from_value(&v, CallFormat::Tag) {
+                calls.push(c);
+            }
+        }
+    }
+
+    if calls.is_empty() {
+        for body in top_level_objects(text) {
+            if !body.contains("\"name\"") {
+                continue;
+            }
+            if let Some(v) = repair_json(body) {
+                if let Some(c) = call_from_value(&v, CallFormat::Bare) {
+                    calls.push(c);
+                }
+            }
+        }
+    }
+
+    calls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_text_tool_calls, repair_json, CallFormat};
+    use serde_json::json;
+
+    #[test]
+    fn parses_well_formed_fenced_call() {
+        let calls = parse_text_tool_calls("Let me look:\n```json\n{\"name\":\"bash\",\"input\":{\"command\":\"ls\"}}\n```\n");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "ls"}));
+        assert_eq!(calls[0].format, CallFormat::Fenced);
+    }
+
+    #[test]
+    fn parses_tool_call_tag() {
+        let calls =
+            parse_text_tool_calls("<tool_call>{\"name\": \"grep\", \"arguments\": {\"pattern\": \"fn main\"}}</tool_call>");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "grep");
+        assert_eq!(calls[0].input, json!({"pattern": "fn main"}));
+        assert_eq!(calls[0].format, CallFormat::Tag);
+    }
+
+    #[test]
+    fn parses_bare_json_object() {
+        let calls = parse_text_tool_calls("I will run {\"name\":\"bash\",\"parameters\":{\"command\":\"pwd\"}} now");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].format, CallFormat::Bare);
+    }
+
+    #[test]
+    fn recovers_truncated_fence() {
+        // The exact shape observed killing a baseline run: the model stopped
+        // mid-fence, leaving the object unterminated.
+        let calls = parse_text_tool_calls("Here we go:\n```json\n{\"name\": \"bash\", \"input\": {\"command\": \"git status\"");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "git status"}));
+    }
+
+    #[test]
+    fn repairs_literal_newline_inside_string() {
+        let v = repair_json("{\"command\": \"echo one\ntwo\"}").expect("should repair");
+        assert_eq!(v["command"], "echo one\ntwo");
+    }
+
+    #[test]
+    fn repairs_trailing_comma() {
+        let v = repair_json("{\"a\": 1,}").expect("should repair");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn accepts_openai_function_shape_with_stringified_args() {
+        let calls = parse_text_tool_calls(
+            "<tool_call>{\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}}</tool_call>",
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[0].input, json!({"command": "ls"}));
+    }
+
+    #[test]
+    fn ignores_prose_without_calls() {
+        assert!(parse_text_tool_calls("The build passed and there are no TODOs.").is_empty());
+    }
+
+    #[test]
+    fn ignores_json_without_a_name_field() {
+        assert!(parse_text_tool_calls("Result was {\"count\": 3, \"ok\": true}").is_empty());
+    }
+
+    #[test]
+    fn does_not_treat_brace_inside_string_as_structure() {
+        let calls =
+            parse_text_tool_calls("{\"name\":\"bash\",\"input\":{\"command\":\"awk '{print $1}' f\"}}");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].input, json!({"command": "awk '{print $1}' f"}));
+    }
+
+    #[test]
+    fn multiple_tagged_calls_are_all_recovered() {
+        let calls = parse_text_tool_calls(
+            "<tool_call>{\"name\":\"bash\",\"input\":{\"command\":\"ls\"}}</tool_call>\
+             <tool_call>{\"name\":\"bash\",\"input\":{\"command\":\"pwd\"}}</tool_call>",
+        );
+        assert_eq!(calls.len(), 2);
+    }
+
+    #[test]
+    fn empty_text_yields_nothing() {
+        assert!(parse_text_tool_calls("").is_empty());
+        assert!(repair_json("   ").is_none());
+    }
+}

--- a/crates/core/src/toolcall_text.rs
+++ b/crates/core/src/toolcall_text.rs
@@ -2,7 +2,7 @@
 //! the native tool-call channel.
 //!
 //! Small local models (qwen2.5:3b class, served through Ollama) regularly slip
-//! out of the OpenAI `tool_calls` channel and write the call into the assistant
+//! out of the `OpenAI` `tool_calls` channel and write the call into the assistant
 //! message body instead — as a ```` ```json ```` fence, a `<tool_call>` tag, or a
 //! bare JSON object. A harness that only reads native `tool_calls` sees an
 //! ordinary end-of-turn and stops the run, so a recoverable formatting slip

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -10,6 +10,43 @@ use std::fmt::Write as _;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+/// Reject a path argument that the sandbox will not accept, telling the model
+/// what to send instead.
+///
+/// A bare refusal ("absolute paths are not allowed") is a dead end for a small
+/// local model: it has no way to derive the accepted form, so it either retries
+/// the same call or abandons the task and apologises in prose. Naming the
+/// working directory and, where it can be derived, the exact corrected path
+/// turns the rejection into something the model can act on in one step.
+fn reject_path(tool: &str, path: &str) -> ToolOutput {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd_display = cwd.display();
+
+    // If the path points inside the working directory, hand back the relative
+    // form directly — the model can retry verbatim.
+    if let Ok(rel) = Path::new(path).strip_prefix(&cwd) {
+        return ToolOutput::err(format!(
+            "`{tool}` takes paths relative to the working directory ({cwd_display}), \
+             not absolute paths. Retry with path=\"{}\".",
+            rel.display()
+        ));
+    }
+
+    ToolOutput::err(format!(
+        "`{tool}` takes paths relative to the working directory ({cwd_display}), \
+         not absolute paths like \"{path}\". Retry with a path relative to that \
+         directory, or use the `bash` tool if you need to reach outside it."
+    ))
+}
+
+/// Reject a `..` path, pointing at the escape hatch that does work.
+fn reject_traversal(tool: &str) -> ToolOutput {
+    ToolOutput::err(format!(
+        "`{tool}` does not allow `..` in paths. Retry with a path that stays \
+         inside the working directory, or use the `bash` tool for anything outside it."
+    ))
+}
+
 /// Echo tool - useful for testing the tool pipeline.
 pub struct EchoTool;
 
@@ -112,10 +149,10 @@ impl ToolHandler for GrepTool {
         // Security: validate path to prevent accessing arbitrary host files
         let p = std::path::Path::new(&path);
         if p.is_absolute() || path.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("grep", &path);
         }
         if p.components().any(|c| c == std::path::Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("grep");
         }
 
         let mut cmd = std::process::Command::new("grep");
@@ -236,10 +273,10 @@ impl ToolHandler for ReadFileTool {
 
         let p = Path::new(&path);
         if p.is_absolute() || path.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("read_file", &path);
         }
         if p.components().any(|c| c == Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("read_file");
         }
 
         match std::fs::read_to_string(&path) {
@@ -435,10 +472,10 @@ impl ToolHandler for WriteFileTool {
 
         let p = Path::new(&raw);
         if p.is_absolute() || raw.starts_with('/') {
-            return ToolOutput::err("absolute paths are not allowed");
+            return reject_path("write_file", &raw);
         }
         if p.components().any(|c| c == Component::ParentDir) {
-            return ToolOutput::err("path traversal (..) is not allowed");
+            return reject_traversal("write_file");
         }
         let path_key = safe_edit_path_key(&raw);
         let file_exists = p.exists();
@@ -786,6 +823,53 @@ mod tests {
         let tool = ReadFileTool;
         let out = tool.call(json!({"path": "/etc/passwd"})).await;
         assert!(out.is_error);
+    }
+
+    /// A bare "not allowed" leaves a small model with nowhere to go — it retries
+    /// the same call or gives up in prose. The rejection must name the rule and
+    /// point at a way forward.
+    #[tokio::test]
+    async fn path_rejection_tells_the_model_what_to_do_instead() {
+        let out = ReadFileTool.call(json!({"path": "/etc/passwd"})).await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("relative"),
+            "rejection should name the accepted form: {}",
+            out.content
+        );
+        assert!(
+            out.content.contains("bash"),
+            "rejection should point at the escape hatch: {}",
+            out.content
+        );
+    }
+
+    /// When the path is inside the working directory the corrected form is
+    /// derivable, so hand it back verbatim — the model can retry in one step.
+    #[tokio::test]
+    async fn path_rejection_suggests_the_exact_relative_path() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let abs = cwd.join("Cargo.toml");
+        let out = ReadFileTool
+            .call(json!({ "path": abs.to_string_lossy() }))
+            .await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("Retry with path=\"Cargo.toml\""),
+            "expected an exact corrected path: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn traversal_rejection_is_actionable() {
+        let out = ReadFileTool.call(json!({"path": "../secret"})).await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("bash"),
+            "traversal rejection should point at the escape hatch: {}",
+            out.content
+        );
     }
 
     #[test]

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -634,6 +634,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registry_rejects_non_string_echo_message() {
+        let registry = crate::registry::ToolRegistry::new();
+        registry.register(EchoTool);
+
+        let out = registry.call("echo", json!({"message": 42})).await;
+
+        assert!(out.is_error);
+        assert!(
+            out.content
+                .contains("field `message` must be of type string"),
+            "expected schema type error, got: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_wrong_content_type_does_not_touch_files() {
+        let _scope = enter_test_fs_scope().await;
+        std::fs::write("existing.txt", "preserve me").expect("seed existing file");
+        let registry = crate::registry::ToolRegistry::new();
+        registry.register(WriteFileTool);
+
+        let create = registry
+            .call("write_file", json!({"path": "new.txt", "content": 42}))
+            .await;
+        let overwrite = registry
+            .call("write_file", json!({"path": "existing.txt", "content": 42}))
+            .await;
+
+        assert!(create.is_error);
+        assert!(overwrite.is_error);
+        assert!(!Path::new("new.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string("existing.txt").expect("read existing file"),
+            "preserve me"
+        );
+    }
+
+    #[tokio::test]
     async fn write_file_requires_read_before_overwrite() {
         let _scope = enter_test_fs_scope().await;
         std::fs::write("existing.txt", "before").expect("seed existing file");

--- a/crates/tools/src/registry.rs
+++ b/crates/tools/src/registry.rs
@@ -142,6 +142,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registry_rejects_wrong_input_type_before_dispatch() {
+        let registry = ToolRegistry::new();
+        registry.register(UpperCase);
+        let out = registry
+            .call("uppercase", serde_json::json!({"text": 42}))
+            .await;
+
+        assert!(out.is_error);
+        assert_eq!(
+            out.content,
+            "invalid input for uppercase: field `text` must be of type string"
+        );
+    }
+
+    #[tokio::test]
     async fn registry_unknown_tool() {
         let registry = ToolRegistry::new();
         let out = registry.call("nonexistent", serde_json::json!({})).await;

--- a/crates/tools/src/schema.rs
+++ b/crates/tools/src/schema.rs
@@ -41,13 +41,18 @@ impl ToolSchema {
         }
     }
 
-    /// Validate an input value against this schema (basic required-field check).
+    /// Validate an input value against the schema shape used by built-in tools.
     ///
     /// # Errors
     ///
-    /// Returns `Err` with a human-readable message naming the first missing required field.
+    /// Returns `Err` with a human-readable message naming the first missing or
+    /// incorrectly typed field.
     pub fn validate(&self, input: &Value) -> Result<(), String> {
         let schema = &self.input_schema;
+        if let Some(expected) = schema.get("type").and_then(Value::as_str) {
+            validate_json_type(input, expected, "input")?;
+        }
+
         if let Some(required) = schema.get("required").and_then(|r| r.as_array()) {
             for field in required {
                 let key = field.as_str().unwrap_or("");
@@ -56,7 +61,39 @@ impl ToolSchema {
                 }
             }
         }
+
+        if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+            for (key, property_schema) in properties {
+                let Some(value) = input.get(key) else {
+                    continue;
+                };
+                let Some(expected) = property_schema.get("type").and_then(Value::as_str) else {
+                    continue;
+                };
+                validate_json_type(value, expected, &format!("field `{key}`"))?;
+            }
+        }
+
         Ok(())
+    }
+}
+
+fn validate_json_type(value: &Value, expected: &str, location: &str) -> Result<(), String> {
+    let matches = match expected {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
+    };
+
+    if matches {
+        Ok(())
+    } else {
+        Err(format!("{location} must be of type {expected}"))
     }
 }
 
@@ -71,5 +108,50 @@ mod tests {
             .validate(&serde_json::json!({"command": "ls"}))
             .is_ok());
         assert!(schema.validate(&serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn rejects_incorrect_required_field_type() {
+        let schema = ToolSchema::simple("echo", "Echo a message", &["message"]);
+        assert_eq!(
+            schema.validate(&serde_json::json!({"message": 42})),
+            Err("field `message` must be of type string".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_input() {
+        let schema = ToolSchema::simple("echo", "Echo a message", &["message"]);
+        assert_eq!(
+            schema.validate(&serde_json::json!("hello")),
+            Err("input must be of type object".to_string())
+        );
+    }
+
+    #[test]
+    fn validates_present_optional_fields_without_requiring_them() {
+        let schema = ToolSchema {
+            name: "grep".to_string(),
+            description: "Search files".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"}
+                },
+                "required": ["pattern"]
+            }),
+        };
+
+        assert!(schema
+            .validate(&serde_json::json!({"pattern": "needle"}))
+            .is_ok());
+        assert!(schema
+            .validate(&serde_json::json!({"pattern": "needle", "recursive": true}))
+            .is_ok());
+        assert_eq!(
+            schema.validate(&serde_json::json!({"pattern": "needle", "recursive": "yes"})),
+            Err("field `recursive` must be of type boolean".to_string())
+        );
     }
 }


### PR DESCRIPTION
Rolls up six reviewed PRs onto one branch. Each was read for correctness before merging; conflicts between them were resolved by hand.

## Included

| PR | Change |
|----|--------|
| #88 | Ollama path survives small-model protocol slips (text-written tool-call recovery, empty-completion retry, malformed-arg repair, turn diagnostics, actionable path rejections) |
| #89 | Tool input property **type** validation, not just required-field presence |
| #90 | Unfinished subagent runs return an error instead of `(sub-agent produced no output)` |
| #91 | Bounded, configurable, actionable Ollama request waits |
| #92 | `anvil chat` interactive mode; provider selection extracted to `commands/provider.rs` |
| #93 | Dogfood alignment findings |

## Conflict resolutions (not verbatim from any single PR)

- **`OllamaProvider` (#88 x #91).** Kept both `temperature` (#88) and `request_timeout` (#91). The timeout is applied **per request**, not on the shared `Client`, so there is one timeout authority rather than layered ones. A timeout propagates immediately out of `complete_once`, so the empty-response retry loop does not stack three waits.
- **Default timeout 60s -> 120s.** #88 deliberately raised the hard-coded client timeout to 120s for cold local model loads; #91 kept 60s only because it was preserving the existing value while adding `--ollama-timeout-secs`. Took #88's empirical bound now that #91 makes it overridable. README updated to match.
- **`--temperature` (#88 x #92).** #92 deletes the `run.rs` block that #88 attached `--temperature` to, which would have left a dead flag. Moved it onto the shared `ProviderArgs`, so `run` and `chat` both accept it.
- **#93 doc.** The report only referenced the episodic-memory benchmark contamination in a passing clause, and attributed it to #88 as already fixed. It is not fixed. Rewritten as an explicit standing finding — see below.

## Standing finding recorded in `FEEDBACK_REPORT.md`

`anvil run` injects up to 5 goal-matching past episodes into the system prompt on every invocation (`Agent::build_system_prompt_with_memory`, `memory.search(goal, 5)`), from a single per-user SQLite DB under `$HOME`. `--session` does not scope it and no flag reports it.

Any benchmark looping `anvil run` over fixed goals therefore scores run *k* with runs *1..k-1* of the same goal pasted into its prompt. **This withdraws the earlier local fine-tune numbers** — they measured accumulated memory, not model capability, and must not be cited before a re-run under an isolated database.

## Verification (local, Rust 1.86)

- `cargo build --release` — ok
- `cargo test --all` — **115 passed, 0 failed**, 1 ignored
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (matches CI)
- `cargo fmt --all -- --check` — clean
- Binary smoke test under an isolated `$HOME`: `anvil run --provider echo`, `anvil chat` multi-turn + `/exit`, `--temperature` and `--ollama-timeout-secs` present on both subcommands, `--ollama-timeout-secs 0` rejected.