### PR TITLE
fix(cli): exit non-zero when a run does not finish; one iteration cap; allow python

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Only for the things those tools structurally can't do:
 - **It runs with no network and no account.** One static binary plus Ollama. Air-gapped machines, and zero marginal cost per run.
 - **No language runtime to install.** `cargo install` once; there is no `node_modules`, no venv.
 - **It is a library, not just a CLI.** The agent loop, tool registry and memory store are ordinary Rust crates you can embed in your own program.
-- **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result.
+- **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result. `anvil run` exits non-zero when the run did not finish — see [Exit codes](#exit-codes).
 
 Where it does **not** compete: interactive day-to-day coding. Against a frontier model those tools are far faster and far more capable. Measured on a local 9.6 GB model (`gemma4`, M5, fresh `$HOME` per run so episodic memory cannot leak between them): a one-line fix verified by re-running `cargo test` takes a median of 55s and landed 9 times out of 9. A fix spanning two files and two bugs takes a median of 2m44s and landed 5 times out of 7 — twice it did not, and one of those reported success over a still-failing test suite.
 
@@ -129,6 +129,9 @@ anvil run --provider echo --goal "continue the work" --session myproject
 # Batch-evaluate against a JSONL suite of {"goal":"...","expected":"..."} lines
 anvil eval --cases cases.jsonl --provider echo
 
+# Raise or remove the iteration cap for this run (0 = unlimited)
+anvil run --provider ollama --model gemma4 --goal "fix the failing test" --max-iterations 80
+
 # Memory
 anvil memory search "rust async" --limit 10
 anvil memory recent myproject --limit 20     # session name or UUID
@@ -139,6 +142,34 @@ anvil auth status
 ```
 
 `anvil --help` and `anvil <command> --help` are authoritative.
+
+### Exit codes
+
+`anvil run` reports its outcome so an unattended caller can branch on it:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | The agent ended its own turn — it believes it is finished. |
+| `1` | The run aborted: provider error, bad config, unreachable Ollama, I/O failure. |
+| `2` | The run stopped without the agent finishing. Today the only cause is hitting the `--max-iterations` cap. |
+
+Under `--json-output` the same outcome is on the terminal `result` event, so you do not have to shell out to read `$?`:
+
+```json
+{"type":"result","part":{"text":"…","isError":true,"outcome":"max_iterations","sessionId":"…","model":"gemma4"}}
+```
+
+`outcome` is one of `done`, `max_iterations`, `failed`, `cancelled`; `isError` is true for everything except `done`.
+
+**What exit code 0 does *not* mean.** It means the model stopped and said it was done — not that the goal was achieved. In measured runs against a local model, a session ended with `cargo test` still red while the final message claimed success and rationalised the remaining failure away. Anvil does not attempt to detect that: it has no ground truth for an arbitrary natural-language goal, and guessing from the wording of the final message would produce a confidently wrong exit code, which is worse than an honestly ambiguous `0`. Two related cases are also deliberately left as `0`: an agent that gives up in prose without a tool call, and a provider that reports `stop_reason=tool_use` with no tool-use blocks — both are indistinguishable from a legitimate finish from inside the loop.
+
+**If you need to know whether the goal was met, assert it yourself** — run the check outside anvil and branch on *that*:
+
+```bash
+HOME=$(mktemp -d) anvil run --provider ollama --model gemma4 --json-output \
+  --goal "fix the failing test in src/lib.rs" || exit 1   # catches cap exhaustion and hard errors
+cargo test                                                 # your ground truth for "it actually worked"
+```
 
 ---
 
@@ -173,7 +204,8 @@ Tools registered in the shipped binary: `echo`, `read_file`, `write_file`, `grep
 
 Limits worth knowing before you hit them:
 
-- **`bash` commands time out after 30 seconds** and are restricted to an allowlist (`cargo`, `git`, `ls`, `cat`, `grep`, `curl`, `jq`, …). A cold `cargo build` on a non-trivial project will exceed this.
+- **`bash` commands time out after 30 seconds** and are restricted to a hardcoded allowlist (`cargo`, `rustc`, `rustfmt`, `git`, `python3`, `python`, `pytest`, `ls`, `cat`, `echo`, `pwd`, `env`, `which`, `grep`, `bash`, `curl`, `jq`). A cold `cargo build` on a non-trivial project will exceed the timeout. The allowlist is a guard rail against accidental damage, **not** a sandbox: `bash` is on it, so `bash -c '<anything>'` passes the check. It is not configurable, because a config knob would advertise a containment property this gate does not have — if you are running untrusted goals, isolate the process.
+- **The iteration cap defaults to 50** (`agent.max_iterations` in the config; `--max-iterations` overrides it, `0` means unlimited). On a local model a two-file fix has been measured at up to 10 iterations, so the old cap of 10 was a coin flip. Hitting the cap is a failure and exits `2`.
 - **`write_file` requires a prior `read_file`** of that path in the same session, and refuses to write if the file changed since that read. Creating a new file is exempt.
 - **Paths are relative only** — absolute paths and `..` are rejected. Anvil operates on the current working directory.
 

--- a/crates/cli/src/agent.rs
+++ b/crates/cli/src/agent.rs
@@ -60,10 +60,11 @@ pub trait UiHook: Send + Sync {
     fn on_text(&self, text: &str) {
         let _ = text;
     }
-    /// Called at session completion with the final result text.
+    /// Called at session completion with the final result text and the terminal
+    /// session status (the machine-readable outcome of the run).
     /// Default: no-op.
-    fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
-        let _ = (text, is_error, session_id);
+    fn on_result(&self, text: &str, session_id: &str, status: SessionStatus) {
+        let _ = (text, session_id, status);
     }
     /// Called once per completed provider turn with structural diagnostics.
     ///
@@ -300,11 +301,17 @@ impl Agent {
 
         loop {
             if session.iteration >= max_iter {
-                info!("max iterations reached");
+                warn!(
+                    max_iter,
+                    "max iterations reached without the agent finishing"
+                );
                 let last_text = session.messages.last().and_then(|m| m.text()).unwrap_or("");
-                self.hook
-                    .on_result(last_text, false, &session.id.to_string());
-                session.finish(SessionStatus::Done);
+                self.hook.on_result(
+                    last_text,
+                    &session.id.to_string(),
+                    SessionStatus::MaxIterations,
+                );
+                session.finish(SessionStatus::MaxIterations);
                 break;
             }
 
@@ -436,7 +443,7 @@ impl Agent {
 
                     // Notify hook that the session is complete.
                     self.hook
-                        .on_result(&final_text, false, &session.id.to_string());
+                        .on_result(&final_text, &session.id.to_string(), SessionStatus::Done);
 
                     session.finish(SessionStatus::Done);
                     break;
@@ -480,8 +487,11 @@ impl Agent {
                         );
                         let last_text =
                             session.messages.last().and_then(|m| m.text()).unwrap_or("");
-                        self.hook
-                            .on_result(last_text, false, &session.id.to_string());
+                        self.hook.on_result(
+                            last_text,
+                            &session.id.to_string(),
+                            SessionStatus::Done,
+                        );
                         session.finish(SessionStatus::Done);
                         break;
                     };
@@ -510,7 +520,16 @@ impl Agent {
                                 .to_string();
                             info!(sub_goal = %sub_goal, depth = self.depth, "spawning sub-agent");
                             match self.spawn_subagent(&sub_goal, &context).await {
-                                Ok(result) => harness_tools::ToolOutput::ok(result),
+                                Ok((result, SessionStatus::Done)) => {
+                                    harness_tools::ToolOutput::ok(result)
+                                }
+                                // A sub-agent that hit its own cap did not finish;
+                                // surface that as a tool error instead of passing its
+                                // partial text up as a success.
+                                Ok((result, status)) => harness_tools::ToolOutput::err(format!(
+                                    "sub-agent did not complete (outcome: {}); partial output: {result}",
+                                    status.as_str()
+                                )),
                                 Err(e) => {
                                     harness_tools::ToolOutput::err(format!("sub-agent error: {e}"))
                                 }
@@ -641,9 +660,13 @@ impl Agent {
 
     /// Spawn a nested sub-agent to handle a delegated goal.
     ///
-    /// Returns the sub-agent final response text, or an error if depth
-    /// exceeds [`MAX_SUBAGENT_DEPTH`].
-    async fn spawn_subagent(&self, goal: &str, context: &str) -> anyhow::Result<String> {
+    /// Returns the sub-agent final response text and its terminal status, or an
+    /// error if depth exceeds [`MAX_SUBAGENT_DEPTH`].
+    async fn spawn_subagent(
+        &self,
+        goal: &str,
+        context: &str,
+    ) -> anyhow::Result<(String, SessionStatus)> {
         if self.depth >= MAX_SUBAGENT_DEPTH {
             return Err(anyhow::anyhow!(
                 "sub-agent depth limit ({MAX_SUBAGENT_DEPTH}) reached -- cannot spawn further"
@@ -682,10 +705,11 @@ impl Agent {
         info!(
             depth = self.depth,
             result_len = result.len(),
+            status = session.status.as_str(),
             "sub-agent completed"
         );
 
-        Ok(result)
+        Ok((result, session.status))
     }
 }
 
@@ -834,7 +858,13 @@ mod tests {
 
         let session = agent.run("loop forever").await.unwrap();
 
-        assert_eq!(session.status, harness_core::session::SessionStatus::Done);
+        // A run stopped by the cap did not finish its goal: it must not report
+        // `Done` (which is what `anvil run` maps to exit code 0).
+        assert_eq!(
+            session.status,
+            harness_core::session::SessionStatus::MaxIterations
+        );
+        assert_eq!(session.status.exit_code(), 2);
         assert_eq!(session.iteration, 2);
     }
 
@@ -915,7 +945,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result, "context-aware result");
+        assert_eq!(
+            result,
+            (
+                "context-aware result".to_string(),
+                harness_core::session::SessionStatus::Done
+            )
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -19,15 +19,20 @@ pub struct ChatArgs {
     #[arg(long)]
     pub session: Option<String>,
 
-    /// Maximum agent iterations for each prompt (default: 10). Set to 0 for unlimited
-    #[arg(long, default_value_t = 10)]
-    pub max_iterations: usize,
+    /// Maximum agent iterations for each prompt.
+    /// Defaults to `agent.max_iterations` from the config (50). Set to 0 for unlimited
+    #[arg(long)]
+    pub max_iterations: Option<usize>,
 }
 
 pub async fn execute(args: ChatArgs) -> anyhow::Result<()> {
     let config = Config::load()?;
     let resolved = provider::resolve(&config, &args.provider)?;
     let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
+    let max_iterations = crate::commands::run::resolve_max_iterations(
+        args.max_iterations,
+        config.agent.max_iterations,
+    );
     let session_name = args
         .session
         .unwrap_or_else(|| format!("chat-{}", Uuid::new_v4()));
@@ -47,7 +52,7 @@ pub async fn execute(args: ChatArgs) -> anyhow::Result<()> {
     run_chat_loop(
         &agent,
         &session_name,
-        args.max_iterations,
+        max_iterations,
         &mut reader,
         &mut writer,
     )
@@ -61,11 +66,6 @@ async fn run_chat_loop<R: BufRead, W: Write>(
     reader: &mut R,
     writer: &mut W,
 ) -> anyhow::Result<()> {
-    let max_iterations = if max_iterations == 0 {
-        usize::MAX
-    } else {
-        max_iterations
-    };
     let options = RunOptions {
         session_name: Some(session_name.to_string()),
         max_iterations: Some(max_iterations),

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use clap::Args;
 use harness_core::config::Config;
+use harness_core::session::SessionStatus;
 use harness_memory::MemoryDb;
 use indicatif::ProgressBar;
 
@@ -29,17 +30,22 @@ pub struct RunArgs {
     #[arg(long)]
     pub session: Option<String>,
 
-    /// Override the maximum number of agent iterations (default: 10).
+    /// Override the maximum number of agent iterations.
+    /// Defaults to `agent.max_iterations` from the config (50).
     /// Set to 0 for unlimited.
-    #[arg(long, default_value_t = 10)]
-    pub max_iterations: usize,
+    #[arg(long)]
+    pub max_iterations: Option<usize>,
 
     /// Emit structured NDJSON events to stdout instead of human-readable terminal output.
     ///
     /// Each line is a JSON object with a `type` field:
     ///   {"type":"text",     "part":{"text":"..."}}
     ///   {"`type":"tool_use`", "part":{"tool":"bash","callID":"...","state":{"status":"completed","input":{...},"output":"..."}}}
-    ///   {"type":"result",   "part":{"text":"...","isError":false,"sessionId":"..."}}
+    ///   {"type":"result",   "part":{"text":"...","isError":false,"outcome":"done","sessionId":"..."}}
+    ///
+    /// `outcome` is the machine-readable run status: `done` when the agent ended its
+    /// own turn, `max_iterations` when the loop hit `--max-iterations` first. `isError`
+    /// is true for every outcome other than `done`, and the process then exits 2.
     ///
     /// Use this flag when calling `anvil run` from a machine-readable context (e.g. Paperclip adapter).
     #[arg(long)]
@@ -219,12 +225,13 @@ impl UiHook for JsonHook {
         }));
     }
 
-    fn on_result(&self, text: &str, is_error: bool, session_id: &str) {
+    fn on_result(&self, text: &str, session_id: &str, status: SessionStatus) {
         Self::emit(&serde_json::json!({
             "type": "result",
             "part": {
                 "text": text,
-                "isError": is_error,
+                "isError": status != SessionStatus::Done,
+                "outcome": status.as_str(),
                 "sessionId": session_id,
                 "model": self.model,
             }
@@ -234,9 +241,24 @@ impl UiHook for JsonHook {
 
 // ── Command entry point ───────────────────────────────────────────────────────
 
+/// Resolve the iteration cap for this run: the `--max-iterations` flag when
+/// given, otherwise `agent.max_iterations` from config. `0` means unlimited in
+/// both places.
+pub(crate) fn resolve_max_iterations(flag: Option<usize>, config_value: usize) -> usize {
+    match flag.unwrap_or(config_value) {
+        0 => usize::MAX,
+        n => n,
+    }
+}
+
+/// Run the agent and return the terminal session status.
+///
+/// The caller maps that status to a process exit code via
+/// [`SessionStatus::exit_code`] — a run that never finished must not look like
+/// a success to an unattended caller.
 // Long but linear: a single top-to-bottom flow; splitting it would only scatter state.
 #[allow(clippy::too_many_lines)]
-pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
+pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
     let config = Config::load()?;
     let resolved = provider::resolve(&config, &args.provider)?;
     let backend = resolved.backend;
@@ -245,7 +267,15 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
 
     let memory = Arc::new(MemoryDb::open(&config.memory.db_path).await?);
 
-    if args.stream {
+    let opts = RunOptions {
+        session_name: args.session.clone(),
+        max_iterations: Some(resolve_max_iterations(
+            args.max_iterations,
+            config.agent.max_iterations,
+        )),
+    };
+
+    let status = if args.stream {
         // Streaming mode: run through the Agent loop (with tools) using CliHook.
         let hook = CliHook::new();
         let agent = Agent::new(Arc::clone(&provider), Arc::clone(&memory), config.clone())
@@ -253,15 +283,6 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
 
         ui::print_banner();
         ui::print_session_header("stream", &model, &backend);
-
-        let opts = RunOptions {
-            session_name: args.session.clone(),
-            max_iterations: if args.max_iterations == 0 {
-                Some(usize::MAX)
-            } else {
-                Some(args.max_iterations)
-            },
-        };
 
         let session = agent.run_with_options(&args.goal, opts).await?;
 
@@ -275,22 +296,14 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
         }
 
         println!("Streaming complete.");
+        session.status
     } else if args.json_output {
         // JSON output mode: emit NDJSON events to stdout, no terminal UI.
         let hook = JsonHook::new(&model);
         let agent = Agent::new(Arc::clone(&provider), Arc::clone(&memory), config.clone())
             .with_hook(Arc::clone(&hook) as Arc<dyn UiHook>);
 
-        let opts = RunOptions {
-            session_name: args.session.clone(),
-            max_iterations: if args.max_iterations == 0 {
-                Some(usize::MAX)
-            } else {
-                Some(args.max_iterations)
-            },
-        };
-
-        agent.run_with_options(&args.goal, opts).await?;
+        agent.run_with_options(&args.goal, opts).await?.status
     } else {
         // Default terminal UI mode.
         let hook = CliHook::new();
@@ -305,15 +318,6 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
             eprintln!("  session name: {sname}\n");
         }
 
-        let opts = RunOptions {
-            session_name: args.session.clone(),
-            max_iterations: if args.max_iterations == 0 {
-                Some(usize::MAX)
-            } else {
-                Some(args.max_iterations)
-            },
-        };
-
         let t0 = Instant::now();
         let session = agent.run_with_options(&args.goal, opts).await?;
         let elapsed_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -324,7 +328,39 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<()> {
 
         ui::print_session_summary(0, 0, session.iteration, elapsed_ms);
         eprintln!("  session {} | status {:?}", session.id, session.status);
+        session.status
+    };
+
+    if status == SessionStatus::MaxIterations {
+        eprintln!(
+            "error: agent stopped at the --max-iterations cap without finishing its goal \
+             (outcome: {}, exit code {})",
+            status.as_str(),
+            status.exit_code()
+        );
     }
 
-    Ok(())
+    Ok(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_max_iterations, SessionStatus};
+
+    #[test]
+    fn flag_overrides_config_and_zero_means_unlimited() {
+        assert_eq!(resolve_max_iterations(Some(3), 50), 3);
+        assert_eq!(resolve_max_iterations(None, 50), 50);
+        assert_eq!(resolve_max_iterations(Some(0), 50), usize::MAX);
+        assert_eq!(resolve_max_iterations(None, 0), usize::MAX);
+    }
+
+    #[test]
+    fn only_a_finished_agent_turn_exits_zero() {
+        assert_eq!(SessionStatus::Done.exit_code(), 0);
+        assert_eq!(SessionStatus::MaxIterations.exit_code(), 2);
+        assert_eq!(SessionStatus::Failed.exit_code(), 2);
+        assert_eq!(SessionStatus::Cancelled.exit_code(), 2);
+        assert_eq!(SessionStatus::MaxIterations.as_str(), "max_iterations");
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,7 +56,17 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     match cli.command {
-        Commands::Run(args) => commands::run::execute(args).await,
+        Commands::Run(args) => {
+            // A run that never finished must not report success to an unattended
+            // caller, so the terminal session status picks the exit code.
+            let status = commands::run::execute(args).await?;
+            let code = status.exit_code();
+            if code != 0 {
+                std::io::Write::flush(&mut std::io::stdout())?;
+                std::process::exit(code);
+            }
+            Ok(())
+        }
         Commands::Chat(args) => commands::chat::execute(args).await,
         Commands::Config(args) => commands::config::execute(args).await,
         Commands::Memory(args) => commands::memory::execute(args).await,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -20,8 +20,40 @@ pub struct Session {
 pub enum SessionStatus {
     Running,
     Done,
+    /// The loop hit its iteration cap before the agent ended its turn. The goal
+    /// was *not* reported complete — this is an unambiguous, harness-observable
+    /// failure.
+    MaxIterations,
     Failed,
     Cancelled,
+}
+
+impl SessionStatus {
+    /// Stable lowercase name, used as the machine-readable `outcome` field.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Done => "done",
+            Self::MaxIterations => "max_iterations",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Process exit code for a finished run.
+    ///
+    /// `0` only when the agent ended its own turn (`Done`). Note this says the
+    /// agent *finished*, not that the goal was actually achieved — the harness
+    /// cannot verify the latter.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        if *self == Self::Done {
+            0
+        } else {
+            2
+        }
+    }
 }
 
 impl Session {

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -291,12 +291,18 @@ impl ToolHandler for ReadFileTool {
 }
 
 /// Executes a shell command and returns stdout/stderr.
-/// Security: only commands whose first token appears in `ALLOWED_COMMANDS` are permitted.
+///
+/// Only commands whose first token appears in `ALLOWED_COMMANDS` are permitted.
+/// This is a guard rail against accidental damage, **not** a security boundary:
+/// `bash` is itself on the list, so `bash -c '<anything>'` passes the check. It
+/// is kept because it catches the common accidents cheaply; it is deliberately
+/// not made configurable, because a knob would imply a containment property this
+/// gate does not have. Run untrusted goals in a sandbox, not behind this list.
 pub struct BashExecTool;
 
 const ALLOWED_COMMANDS: &[&str] = &[
     "cargo", "rustfmt", "rustc", "git", "ls", "cat", "echo", "pwd", "env", "which", "grep", "bash",
-    "curl", "jq",
+    "curl", "jq", "python3", "python", "pytest",
 ];
 
 fn sandbox_violation_hint(command: &str, stderr: &str) -> Option<String> {
@@ -601,6 +607,21 @@ mod tests {
         );
     }
 
+    /// Without `python3` on the allowlist an edit-build-fix loop is Rust-only.
+    #[tokio::test]
+    async fn bash_exec_python3_allowed() {
+        let tool = BashExecTool;
+        let out = tool
+            .call(json!({"command": "python3 -c 'print(7*6)'"}))
+            .await;
+        assert!(!out.is_error, "unexpected error: {}", out.content);
+        assert!(
+            out.content.contains("42"),
+            "expected 42 in: {}",
+            out.content
+        );
+    }
+
     #[tokio::test]
     async fn bash_exec_cargo_version_allowed() {
         let tool = BashExecTool;
@@ -647,7 +668,7 @@ mod tests {
     async fn bash_exec_rejects_non_allowlisted_command_after_env_assignments() {
         let tool = BashExecTool;
         let out = tool
-            .call(json!({"command": "FOO=bar python -c 'print(1)'"}))
+            .call(json!({"command": "FOO=bar rm -rf /tmp/nope"}))
             .await;
         assert!(out.is_error, "expected non-allowlisted command to fail");
         assert!(


### PR DESCRIPTION
Three defects found by instrumented measurement — 16 real end-to-end runs against a local `gemma4` via Ollama, fresh `$HOME` per run so episodic memory could not leak between them.

## 1. `anvil run` exited 0 whether or not the goal was achieved

Two of the 16 runs finished with the target test suite still failing and still returned `rc=0`. A caller of the advertised `--json-output` unattended pipeline could not distinguish "fixed it" from "gave up".

Root cause: the agent loop's max-iterations branch called `session.finish(SessionStatus::Done)` — the same status a real end-of-turn produces — and `execute` returned `Ok(())` unconditionally.

- New `SessionStatus::MaxIterations`, with `as_str()` (machine-readable outcome) and `exit_code()` (0 only for `Done`).
- `anvil run` exits **2** for any terminal status other than `Done`, and prints a reason to stderr.
- The `--json-output` `result` event now carries `"outcome"` alongside `"isError"`:
  `{"type":"result","part":{"text":"…","isError":true,"outcome":"max_iterations",…}}`
- A sub-agent that exhausts its own cap is returned to the parent as a **tool error** instead of a successful result — the same defect one level down.

### Where the line was drawn

"The model claimed success but was wrong" is **not** detected, on purpose. The harness has no ground truth for an arbitrary natural-language goal, and inferring failure from the wording of the final message would produce a confidently wrong exit code — worse than an honest `0`. Two adjacent cases are also left as `0` for the same reason: prose give-up without a tool call, and `stop_reason=tool_use` with no tool-use blocks (that path may still have produced usable text). All three are documented in a new README **Exit codes** section, together with the pattern for asserting the goal yourself:

```bash
HOME=$(mktemp -d) anvil run … --json-output || exit 1   # cap exhaustion + hard errors
cargo test                                               # your ground truth
```

## 2. Two disagreeing iteration caps

`Config::default()` said 50; clap's `default_value_t = 10` always won. **Chose 50**, as one number: the flag is now `Option<usize>` and falls back to `agent.max_iterations`, so config is the single source of truth (`0` still means unlimited) — and the shadowing is fixed at the source rather than in each of the three `run.rs` branches. `chat` had the same hardcoded 10 and gets the same treatment. 10 was measurably too low: 3 of 7 runs on a two-file task consumed the whole budget, two only landed *on* iteration 10, one failed at the cap. A cap is a ceiling, not a target, so the cost of 50 is bounded by the tasks that would otherwise fail.

## 3. Hardcoded bash allowlist

Added `python3`, `python`, `pytest`. **Deliberately not made configurable**: `bash` is itself on the allowlist, so `bash -c '<anything>'` already passes the check — the gate is a guard rail against accidents, not a sandbox. A config knob would advertise a containment property it does not have. Said exactly that in the code comment and the README.

## Proof, from real runs (not just unit tests)

Release binary, fresh `$HOME`, `memory_injected=0` verified on both:

| Run | Task | Cap | rc | `result` event |
|-----|------|-----|----|----------------|
| forced cap-out | 2-file / 2-bug | 3 | **2** | `"isError":true,"outcome":"max_iterations"` |
| success | 1-file / 1-bug | 50 | **0** | `"isError":false,"outcome":"done"` |

Gates: `cargo build --release`, `cargo test --all` (all suites pass), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all -- --check` (clean).

## Test changes, called out

Neither is a weakened assertion:
- `max_iterations_cap_is_respected` asserted `SessionStatus::Done` after a cap-out — that assertion *encoded the bug*. It now asserts `MaxIterations` and `exit_code() == 2`.
- `bash_exec_rejects_non_allowlisted_command_after_env_assignments` used `python` as its disallowed example; its actual subject is env-assignment token skipping, so it now uses `rm`.

New: `bash_exec_python3_allowed`, and two unit tests covering cap resolution and the status→exit-code mapping.

## Left undone

- No dedicated unit test for the sub-agent cap-out branch — driving a nested agent to its cap through a scripted provider costs more scaffolding than the 3-line match arm is worth. Both of its arms terminate in `ToolOutput::err`.
- `--stream` and `--json-output` still ignore each other's modes; unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)