### PR TITLE
docs: name Ollama as a prerequisite in the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ anvil --help
 ## Quick start
 
 The verified end-to-end path is a local [Ollama](https://ollama.com) model — no API key, no network.
+Install Ollama first if you do not have it (`brew install ollama`, or a package from
+[ollama.com/download](https://ollama.com/download)); the commands below assume the `ollama`
+binary is on your `PATH`. To try Anvil with no model at all, skip to the `echo` provider below.
 
 ```bash
 ollama serve


### PR DESCRIPTION
An out-of-box test — fresh clone, throwaway `$HOME`, README followed literally — found that the Quick start section opens with `ollama serve`, having only linked ollama.com in the prose above it. A reader who does not already have Ollama installed hits `command not found` on the very first command of the front-door example.

Adds the install step and points readers who want zero setup at the `echo` provider, which is already documented further down but easy to miss when the first code block fails.

Docs only; no code change.