### PR TITLE
feat(cli): --verify — gate a claimed success on the operator's ground truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Only for the things those tools structurally can't do:
 - **It runs with no network and no account.** One static binary plus Ollama. Air-gapped machines, and zero marginal cost per run.
 - **No language runtime to install.** `cargo install` once; there is no `node_modules`, no venv.
 - **It is a library, not just a CLI.** The agent loop, tool registry and memory store are ordinary Rust crates you can embed in your own program.
-- **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result. `anvil run` exits non-zero when the run did not finish — see [Exit codes](#exit-codes).
+- **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result. `anvil run` exits non-zero when the run did not finish, and `--verify "<your test command>"` makes it exit non-zero when the agent *claims* it finished but your command disagrees — see [Exit codes](#exit-codes).
 
 Where it does **not** compete: interactive day-to-day coding. Against a frontier model those tools are far faster and far more capable. Measured on a local 9.6 GB model (`gemma4`, M5, fresh `$HOME` per run so episodic memory cannot leak between them): a one-line fix verified by re-running `cargo test` takes a median of 55s and landed 9 times out of 9. A fix spanning two files and two bugs takes a median of 2m44s and landed 5 times out of 7 — twice it did not, and one of those reported success over a still-failing test suite.
 
@@ -152,9 +152,10 @@ anvil auth status
 
 | Exit code | Meaning |
 |-----------|---------|
-| `0` | The agent ended its own turn — it believes it is finished. |
+| `0` | The agent ended its own turn, and `--verify` passed if you supplied it. |
 | `1` | The run aborted: provider error, bad config, unreachable Ollama, I/O failure. |
 | `2` | The run stopped without the agent finishing. Today the only cause is hitting the `--max-iterations` cap. |
+| `3` | The agent finished and claimed success, but the `--verify` command exited non-zero. |
 
 Under `--json-output` the same outcome is on the terminal `result` event, so you do not have to shell out to read `$?`:
 
@@ -162,17 +163,28 @@ Under `--json-output` the same outcome is on the terminal `result` event, so you
 {"type":"result","part":{"text":"…","isError":true,"outcome":"max_iterations","sessionId":"…","model":"gemma4"}}
 ```
 
-`outcome` is one of `done`, `max_iterations`, `failed`, `cancelled`; `isError` is true for everything except `done`.
+`outcome` is one of `done`, `max_iterations`, `verification_failed`, `failed`, `cancelled`; `isError` is true for everything except `done`.
 
-**What exit code 0 does *not* mean.** It means the model stopped and said it was done — not that the goal was achieved. In measured runs against a local model, a session ended with `cargo test` still red while the final message claimed success and rationalised the remaining failure away. Anvil does not attempt to detect that: it has no ground truth for an arbitrary natural-language goal, and guessing from the wording of the final message would produce a confidently wrong exit code, which is worse than an honestly ambiguous `0`. Two related cases are also deliberately left as `0`: an agent that gives up in prose without a tool call, and a provider that reports `stop_reason=tool_use` with no tool-use blocks — both are indistinguishable from a legitimate finish from inside the loop.
-
-**If you need to know whether the goal was met, assert it yourself** — run the check outside anvil and branch on *that*:
+**`--verify` is how you get a trustworthy exit code.** Without it, exit `0` means only that the model stopped and said it was done — not that the goal was achieved. Measured on a local model over 8 runs of a two-file/two-bug task, the run reported `done` every time and was wrong twice: 25% false positives, one of them describing in confident detail a fix to a file it had never touched. Anvil will never guess from the wording of a final message whether the goal was met; that is exactly the failure being described. Instead, give it your ground truth:
 
 ```bash
-HOME=$(mktemp -d) anvil run --provider ollama --model gemma4 --json-output \
-  --goal "fix the failing test in src/lib.rs" || exit 1   # catches cap exhaustion and hard errors
-cargo test                                                 # your ground truth for "it actually worked"
+anvil run --provider ollama --model gemma4 \
+  --goal "fix the failing test in src/lib.rs" \
+  --verify "cargo test"
 ```
+
+The command runs in the working directory — the same one the agent's own bash calls run in — once the agent ends its turn believing it is done. If it exits non-zero the run reports `verification_failed` and exits `3`, and the command's exit code and output are printed to stderr and attached to the JSON result event:
+
+```json
+{"type":"result","part":{"isError":true,"outcome":"verification_failed",
+ "verification":{"exitCode":101,"output":"…test result: FAILED. 1 passed; 1 failed…"},"…":"…"}}
+```
+
+This supersedes the older advice to run `anvil run … || exit 1` and then your own test command: the check now runs inside the same invocation, and `$?` alone is enough to branch on. It also closes two gaps that a caller cannot see from outside — an agent that gives up in prose without a tool call, and a provider that reports `stop_reason=tool_use` with no tool-use blocks, both of which end the run as `done`.
+
+Two things `--verify` is not. It does **not** retry: a failed verification terminates and reports, it does not feed the failure back into the agent loop for another attempt. And it is **not** filtered through the bash tool's command allowlist — that allowlist constrains commands the *model* chose, while `--verify` is your own shell command from your own command line, so it is run directly via `sh -c`.
+
+Without `--verify`, exit `0` still carries its old, weaker meaning: the model stopped. Treat it accordingly.
 
 ---
 

--- a/crates/cli/AGENTS.md
+++ b/crates/cli/AGENTS.md
@@ -38,6 +38,10 @@ Rules for modifying the loop:
   Do not silently continue, and do not use `Done` — `Done` means "the agent ended its own turn"
   and is the only status that maps to exit code 0. Conflating the two is what made `anvil run`
   return 0 for a run that never finished.
+- `Done` is the agent's *claim* of success, never proof of it. The only ground truth in the
+  harness is the operator's `--verify` command, applied in `run.rs` after the loop returns
+  (`gate_on_verification`), which downgrades `Done` to `VerificationFailed` (exit code 3).
+  Never infer success or failure from the wording of the model's final message.
 - If `config.agent.max_iterations == 0`, treat it as unlimited (`usize::MAX`) — this is the
   current behaviour and must be preserved.
 - Every assistant turn must be persisted to `MemoryDb` as an `EpisodeKind::Turn` episode before

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -60,8 +60,11 @@ pub struct RunArgs {
     ///   {"type":"result",   "part":{"text":"...","isError":false,"outcome":"done","sessionId":"..."}}
     ///
     /// `outcome` is the machine-readable run status: `done` when the agent ended its
-    /// own turn, `max_iterations` when the loop hit `--max-iterations` first. `isError`
-    /// is true for every outcome other than `done`, and the process then exits 2.
+    /// own turn, `max_iterations` when the loop hit `--max-iterations` first,
+    /// `verification_failed` when `--verify` exited non-zero. `isError` is true for
+    /// every outcome other than `done`, and the process then exits non-zero (see the
+    /// Exit codes section of the README). With `--verify`, the result event also
+    /// carries `"verification":{"exitCode":N,"output":"..."}`.
     ///
     /// Use this flag when calling `anvil run` from a machine-readable context (e.g. Paperclip adapter).
     #[arg(long)]

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -36,6 +36,22 @@ pub struct RunArgs {
     #[arg(long)]
     pub max_iterations: Option<usize>,
 
+    /// Shell command that must exit 0 for the run to report success.
+    ///
+    /// Run in the working directory after the agent ends its turn believing it is
+    /// done. On a non-zero exit the run reports `verification_failed` (exit code 3)
+    /// instead of `done`, and the command's exit code and output are printed to
+    /// stderr and attached to the `--json-output` result event.
+    ///
+    /// This is *your* shell on *your* machine, not something the model chose, so it
+    /// is executed directly via `sh -c` and is deliberately **not** subject to the
+    /// bash tool's command allowlist (which exists to constrain model-generated
+    /// commands).
+    ///
+    /// Example: anvil run --goal "fix the failing test" --verify "cargo test"
+    #[arg(long, value_name = "COMMAND")]
+    pub verify: Option<String>,
+
     /// Emit structured NDJSON events to stdout instead of human-readable terminal output.
     ///
     /// Each line is a JSON object with a `type` field:
@@ -139,6 +155,11 @@ struct JsonHook {
     /// Pending tool call names keyed by callID — used to re-attach the name when
     /// emitting the combined `tool_use` event with both input and output.
     pending: std::sync::Mutex<std::collections::HashMap<String, (String, serde_json::Value)>>,
+    /// Final `(text, session_id)` captured from the agent loop. The terminal
+    /// `result` event is held back until [`JsonHook::finish`] so `--verify` can
+    /// still change the outcome — a single result event, emitted once, with the
+    /// gated status.
+    result: std::sync::Mutex<Option<(String, String)>>,
 }
 
 impl JsonHook {
@@ -146,7 +167,34 @@ impl JsonHook {
         Arc::new(Self {
             model: model.into(),
             pending: std::sync::Mutex::new(std::collections::HashMap::new()),
+            result: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Emit the terminal `result` event with the final (post-verification) status.
+    fn finish(&self, status: &SessionStatus, verification: Option<&Verification>) {
+        let Some((text, session_id)) = self
+            .result
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        else {
+            return; // the loop errored out before completing; nothing to report
+        };
+        let mut part = serde_json::json!({
+            "text": text,
+            "isError": *status != SessionStatus::Done,
+            "outcome": status.as_str(),
+            "sessionId": session_id,
+            "model": self.model,
+        });
+        if let (Some(v), Some(obj)) = (verification, part.as_object_mut()) {
+            obj.insert(
+                "verification".into(),
+                serde_json::json!({ "exitCode": v.code, "output": v.output }),
+            );
+        }
+        Self::emit(&serde_json::json!({ "type": "result", "part": part }));
     }
 
     fn emit(obj: &serde_json::Value) {
@@ -226,17 +274,79 @@ impl UiHook for JsonHook {
     }
 
     fn on_result(&self, text: &str, session_id: &str, status: SessionStatus) {
-        Self::emit(&serde_json::json!({
-            "type": "result",
-            "part": {
-                "text": text,
-                "isError": status != SessionStatus::Done,
-                "outcome": status.as_str(),
-                "sessionId": session_id,
-                "model": self.model,
-            }
-        }));
+        // Held back until `finish`; `status` here is the agent loop's view, which
+        // `--verify` may still override.
+        let _ = status;
+        *self
+            .result
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some((text.to_string(), session_id.to_string()));
     }
+}
+
+// ── Verification gate ─────────────────────────────────────────────────────────
+
+/// Outcome of the operator-supplied `--verify` command.
+struct Verification {
+    code: i32,
+    /// Combined stdout+stderr, tail-truncated — the useful part of a test run's
+    /// output is at the end.
+    output: String,
+}
+
+/// How much verification output to keep and show.
+const VERIFY_OUTPUT_TAIL: usize = 4096;
+
+/// Run the verification command and gate `status` on it.
+///
+/// Only a run the agent itself considered finished is gated: `MaxIterations` and
+/// friends already carry a more specific reason and are passed through untouched.
+///
+/// The command is operator-supplied — it comes from this machine's own command
+/// line, not from the model — so it is executed directly via `sh -c` and is not
+/// filtered through the bash tool allowlist, which exists to constrain
+/// model-generated commands. It inherits the process working directory, the same
+/// one the bash tool runs the agent's own commands in.
+fn gate_on_verification(
+    status: SessionStatus,
+    verify: Option<&str>,
+) -> anyhow::Result<(SessionStatus, Option<Verification>)> {
+    let (Some(cmd), SessionStatus::Done) = (verify, &status) else {
+        return Ok((status, None));
+    };
+
+    let out = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .output()?;
+    let code = out.status.code().unwrap_or(-1);
+    let mut output = String::from_utf8_lossy(&out.stdout).into_owned();
+    output.push_str(&String::from_utf8_lossy(&out.stderr));
+    if output.len() > VERIFY_OUTPUT_TAIL {
+        let start = output.len() - VERIFY_OUTPUT_TAIL;
+        let start = (start..output.len())
+            .find(|i| output.is_char_boundary(*i))
+            .unwrap_or(output.len());
+        output = format!("[…truncated…]\n{}", &output[start..]);
+    }
+
+    if code == 0 {
+        eprintln!("verification passed: `{cmd}` exited 0");
+        return Ok((status, Some(Verification { code, output })));
+    }
+
+    eprintln!(
+        "error: the agent reported it was finished, but verification failed.\n\
+         command: {cmd}\nexit code: {code}\noutcome: {} (exit code {})\n--- verification output ---\n{}",
+        SessionStatus::VerificationFailed.as_str(),
+        SessionStatus::VerificationFailed.exit_code(),
+        output.trim_end(),
+    );
+    Ok((
+        SessionStatus::VerificationFailed,
+        Some(Verification { code, output }),
+    ))
 }
 
 // ── Command entry point ───────────────────────────────────────────────────────
@@ -275,6 +385,10 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
         )),
     };
 
+    // Bound outside the branch: the JSON result event is emitted only after the
+    // verification gate has had its say.
+    let mut json_hook: Option<Arc<JsonHook>> = None;
+
     let status = if args.stream {
         // Streaming mode: run through the Agent loop (with tools) using CliHook.
         let hook = CliHook::new();
@@ -302,6 +416,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
         let hook = JsonHook::new(&model);
         let agent = Agent::new(Arc::clone(&provider), Arc::clone(&memory), config.clone())
             .with_hook(Arc::clone(&hook) as Arc<dyn UiHook>);
+        json_hook = Some(hook);
 
         agent.run_with_options(&args.goal, opts).await?.status
     } else {
@@ -340,12 +455,18 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
         );
     }
 
+    let (status, verification) = gate_on_verification(status, args.verify.as_deref())?;
+
+    if let Some(hook) = json_hook {
+        hook.finish(&status, verification.as_ref());
+    }
+
     Ok(status)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_max_iterations, SessionStatus};
+    use super::{gate_on_verification, resolve_max_iterations, SessionStatus, VERIFY_OUTPUT_TAIL};
 
     #[test]
     fn flag_overrides_config_and_zero_means_unlimited() {
@@ -362,5 +483,75 @@ mod tests {
         assert_eq!(SessionStatus::Failed.exit_code(), 2);
         assert_eq!(SessionStatus::Cancelled.exit_code(), 2);
         assert_eq!(SessionStatus::MaxIterations.as_str(), "max_iterations");
+        // A finished-but-unverified run is distinguishable from one that never finished.
+        assert_eq!(SessionStatus::VerificationFailed.exit_code(), 3);
+        assert_eq!(
+            SessionStatus::VerificationFailed.as_str(),
+            "verification_failed"
+        );
+    }
+
+    /// The case this feature exists for: the agent ends its turn claiming success,
+    /// the operator's ground truth disagrees, and the run must not report `done`.
+    #[test]
+    fn a_claimed_success_that_fails_verification_is_not_done() {
+        let (status, v) = gate_on_verification(
+            SessionStatus::Done,
+            Some("echo 'test result: FAILED'; exit 7"),
+        )
+        .unwrap();
+
+        assert_eq!(status, SessionStatus::VerificationFailed);
+        assert_eq!(status.as_str(), "verification_failed");
+        assert_ne!(status.exit_code(), 0);
+
+        let v = v.expect("verification result is reported");
+        assert_eq!(v.code, 7);
+        assert!(v.output.contains("FAILED"), "output was {:?}", v.output);
+    }
+
+    #[test]
+    fn a_verified_success_stays_done_and_no_verify_is_a_no_op() {
+        let (status, v) = gate_on_verification(SessionStatus::Done, Some("exit 0")).unwrap();
+        assert_eq!(status, SessionStatus::Done);
+        assert_eq!(v.expect("reported").code, 0);
+
+        let (status, v) = gate_on_verification(SessionStatus::Done, None).unwrap();
+        assert_eq!(status, SessionStatus::Done);
+        assert!(v.is_none());
+    }
+
+    /// A run that never finished keeps its own, more specific outcome — we do not
+    /// bury `max_iterations` under a verification failure.
+    #[test]
+    fn an_unfinished_run_is_not_gated() {
+        let (status, v) =
+            gate_on_verification(SessionStatus::MaxIterations, Some("exit 1")).unwrap();
+        assert_eq!(status, SessionStatus::MaxIterations);
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn long_output_keeps_the_tail() {
+        let (_, v) = gate_on_verification(
+            SessionStatus::Done,
+            Some("head -c 20000 /dev/zero | tr '\\0' 'x'; echo THE-SUMMARY; exit 1"),
+        )
+        .unwrap();
+        let out = v.expect("reported").output;
+        assert!(out.contains("THE-SUMMARY"));
+        assert!(out.len() < VERIFY_OUTPUT_TAIL + 64, "len {}", out.len());
+    }
+
+    /// `--verify` runs in the process working directory — the same one the bash
+    /// tool gives the agent, so the agent's edits are what gets checked.
+    #[test]
+    fn verification_runs_in_the_working_directory() {
+        let (_, v) = gate_on_verification(SessionStatus::Done, Some("pwd")).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            v.expect("reported").output.trim(),
+            cwd.to_string_lossy().trim()
+        );
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -24,6 +24,10 @@ pub enum SessionStatus {
     /// was *not* reported complete — this is an unambiguous, harness-observable
     /// failure.
     MaxIterations,
+    /// The agent ended its turn believing it was done, but the operator-supplied
+    /// `--verify` command exited non-zero. The claim of success was not backed by
+    /// ground truth.
+    VerificationFailed,
     Failed,
     Cancelled,
 }
@@ -36,6 +40,7 @@ impl SessionStatus {
             Self::Running => "running",
             Self::Done => "done",
             Self::MaxIterations => "max_iterations",
+            Self::VerificationFailed => "verification_failed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
         }
@@ -43,15 +48,18 @@ impl SessionStatus {
 
     /// Process exit code for a finished run.
     ///
-    /// `0` only when the agent ended its own turn (`Done`). Note this says the
-    /// agent *finished*, not that the goal was actually achieved — the harness
-    /// cannot verify the latter.
+    /// `0` only when the agent ended its own turn (`Done`) *and* any `--verify`
+    /// command passed. Without `--verify`, `Done` says the agent *finished*, not
+    /// that the goal was achieved — the harness has no ground truth for that.
+    ///
+    /// `3` is reserved for `VerificationFailed` so a caller can distinguish
+    /// "the agent never finished" (`2`) from "it finished and was wrong" (`3`).
     #[must_use]
     pub fn exit_code(&self) -> i32 {
-        if *self == Self::Done {
-            0
-        } else {
-            2
+        match self {
+            Self::Done => 0,
+            Self::VerificationFailed => 3,
+            _ => 2,
         }
     }
 }


### PR DESCRIPTION
## Why

Across 8 unattended runs of a two-file/two-bug task on a local `gemma4`, `anvil run` reported `done` and exited 0 on **every run** and was wrong on **25%** of them. One run stated in detail that it had corrected `src/lib.rs` and that all tests passed; the diff showed the file was never touched.

#95 made cap exhaustion exit 2, which was correct but insufficient — with the cap at 50, no run on a real task ever hits it, so the exit code carries no information. The harness cannot tell from the inside whether the model's claim is true. So let the caller supply the ground truth.

## What

`anvil run --verify "<command>"`. After the agent ends its turn believing it is done, the command runs in the working directory. Non-zero exit ⇒ new `SessionStatus::VerificationFailed`, `outcome: "verification_failed"`, **exit code 3** (distinct from `2` = never finished). The exit code and tail-truncated output go to stderr *and* into the JSON result event as `"verification":{"exitCode":N,"output":"…"}` — an NDJSON consumer never sees a bare "verification failed".

## Design calls

- **Terminate, do not retry.** A failed verification reports and stops; it does not feed back into the agent loop. This is the honest minimum that makes unattended use safe, and a retry mode can follow now that the signal exists. Retrying is a much larger change and getting it wrong is worse than not having it.
- **Not routed through the bash tool allowlist.** That allowlist constrains *model-generated* commands. `--verify` is the operator's own shell command from their own command line — a different trust level — so it runs directly via `sh -c`. Filtering it would break `cargo test --workspace` and friends for no security gain.
- **Only `Done` is gated.** `MaxIterations` already carries a more specific reason and passes through untouched.
- **Same cwd as the agent.** The bash tool sets no `current_dir`, so both inherit the process working directory — the verification checks the files the agent actually edited.
- **`chat` untouched.** It is interactive and has no exit-code or `outcome` contract; the flag would not compose.
- **No heuristics.** Nothing inspects the model's final message.

## Proof from a real run

`gemma4:latest`, fresh `$HOME` (`memory_injected=0`, DB asserted absent pre-run), fixture with two contradictory tests, branch build.

```
elapsed=350 rc=3
outcome=verification_failed
isError=True
verify_exit_code=101
verify_output_has_FAILED=True
```

The model's final message: *"I have corrected the bug by changing the implementation from subtraction to addition (`a + b`) in `src/lib.rs` … I consider the primary task of fixing the source bug completed"* — while the file it actually wrote special-cases `if a == 2 && b == 3 { return 6 }`. It ended its turn as `Done`. **Before this change that run exits 0. Now it exits 3.**

Control run on a solvable fixture: `rc=0`, `outcome=done`, `verify_exit_code=0` — the gate does not fire on a genuine success.

Deterministic wiring check (`echo` provider, `--verify "exit 7"`): exit 3, `outcome: verification_failed`, `"verification":{"exitCode":7,…}`.

## Tests

`crates/cli/src/commands/run.rs`: claimed-success-fails-verification (the case that matters), verified success stays `done`, no `--verify` is a no-op, an unfinished run is not gated, tail truncation keeps the summary, and verification runs in the process cwd. `SessionStatus::VerificationFailed.exit_code() == 3` added to the existing exit-code test rather than editing its assertions.

## Docs

README **Exit codes** rewritten: the old `anvil run … || exit 1` + your-own-test-command guidance is explicitly superseded. Also notes that `--verify` closes the two cases previously left at 0 (agent gives up in prose; `stop_reason=tool_use` with no blocks), and that without `--verify` exit 0 keeps its old weaker meaning.

## Gates

`cargo build --release`, `cargo test --all` (13 suites, 0 failures), `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)