### PR TITLE
fix(cli): report the gated status in terminal mode; reconcile README batteries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Only for the things those tools structurally can't do:
 - **It is a library, not just a CLI.** The agent loop, tool registry and memory store are ordinary Rust crates you can embed in your own program.
 - **`--json-output` is NDJSON**, so batch/unattended pipelines can parse every tool call and result. `anvil run` exits non-zero when the run did not finish, and `--verify "<your test command>"` makes it exit non-zero when the agent *claims* it finished but your command disagrees — see [Exit codes](#exit-codes).
 
-Where it does **not** compete: interactive day-to-day coding. Against a frontier model those tools are far faster and far more capable. Measured on a local 9.6 GB model (`gemma4`, M5, fresh `$HOME` per run so episodic memory cannot leak between them): a one-line fix verified by re-running `cargo test` takes a median of 55s and landed 9 times out of 9. A fix spanning two files and two bugs takes a median of 2m44s and landed 5 times out of 7 — twice it did not, and one of those reported success over a still-failing test suite.
+Where it does **not** compete: interactive day-to-day coding. Against a frontier model those tools are far faster and far more capable. Measured on a local 9.6 GB model (`gemma4`, M5, fresh `$HOME` per run so episodic memory cannot leak between them): a one-line fix verified by re-running `cargo test` takes a median of 55s and landed 9 times out of 9. A fix spanning two files and two bugs takes a median of 2m44s and landed 5 times out of 7 — twice it did not, and one of those reported success over a still-failing test suite. A later 8-run battery of that same two-file task, against the iteration cap of 50, came out at a median of 5m26s and 6 out of 8; the two failures are the false positives that motivated [`--verify`](#exit-codes).
 
 ---
 
@@ -165,7 +165,7 @@ Under `--json-output` the same outcome is on the terminal `result` event, so you
 
 `outcome` is one of `done`, `max_iterations`, `verification_failed`, `failed`, `cancelled`; `isError` is true for everything except `done`.
 
-**`--verify` is how you get a trustworthy exit code.** Without it, exit `0` means only that the model stopped and said it was done — not that the goal was achieved. Measured on a local model over 8 runs of a two-file/two-bug task, the run reported `done` every time and was wrong twice: 25% false positives, one of them describing in confident detail a fix to a file it had never touched. Anvil will never guess from the wording of a final message whether the goal was met; that is exactly the failure being described. Instead, give it your ground truth:
+**`--verify` is how you get a trustworthy exit code.** Without it, exit `0` means only that the model stopped and said it was done — not that the goal was achieved. In the 8-run battery above, the run reported `done` every time and was wrong twice: 25% false positives, one of them describing in confident detail a fix to a file it had never touched. Anvil will never guess from the wording of a final message whether the goal was met; that is exactly the failure being described. Instead, give it your ground truth:
 
 ```bash
 anvil run --provider ollama --model gemma4 \

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -391,6 +391,9 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
     // Bound outside the branch: the JSON result event is emitted only after the
     // verification gate has had its say.
     let mut json_hook: Option<Arc<JsonHook>> = None;
+    // Likewise the terminal status line: printing it before the gate would report
+    // `Done` for a run that is about to exit 3.
+    let mut terminal_session_id: Option<String> = None;
 
     let status = if args.stream {
         // Streaming mode: run through the Agent loop (with tools) using CliHook.
@@ -445,7 +448,7 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
         }
 
         ui::print_session_summary(0, 0, session.iteration, elapsed_ms);
-        eprintln!("  session {} | status {:?}", session.id, session.status);
+        terminal_session_id = Some(session.id.to_string());
         session.status
     };
 
@@ -459,6 +462,10 @@ pub async fn execute(args: RunArgs) -> anyhow::Result<SessionStatus> {
     }
 
     let (status, verification) = gate_on_verification(status, args.verify.as_deref())?;
+
+    if let Some(id) = terminal_session_id {
+        eprintln!("  session {id} | status {status:?}");
+    }
 
     if let Some(hook) = json_hook {
         hook.finish(&status, verification.as_ref());


### PR DESCRIPTION
Two follow-ups to #98, both honesty fixes.

**Terminal mode announced `Done` on a fabricated success.** The `session … | status {:?}` line printed inside the terminal branch, i.e. before `gate_on_verification` ran, so a run about to exit 3 said `status Done` first and `verification failed` second. The status line now prints after the gate. Verified:

```
error: the agent reported it was finished, but verification failed.
command: exit 9
exit code: 9
outcome: verification_failed (exit code 3)
  session 300e04ab-… | status VerificationFailed
```

**The README quoted two batteries of the same task as if they were one.** Line 31 said the two-file/two-bug task landed "5 times out of 7" at a median of 2m44s; the new Exit codes section cited 8 runs with 2 false positives (median 5m26s). Both are real, from different batteries, but a reader could not tell — in a README whose selling point is honest measurement. Both are now labelled.

Gates: `cargo build --release`, `cargo test --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)